### PR TITLE
fix(sync_tests): fix premature logfile close

### DIFF
--- a/sync_tests/tests/node_sync_test.py
+++ b/sync_tests/tests/node_sync_test.py
@@ -326,10 +326,10 @@ def start_node(
         ).strip()
 
     utils.print_message(type="info_warn", message=f"start node cmd: {cmd}")
+    logfile = open(NODE_LOG_FILE, "w+")
 
     try:
-        with open(NODE_LOG_FILE, "w+") as logfile:
-            subprocess.Popen(cmd.split(" "), stdout=logfile, stderr=logfile)
+        subprocess.Popen(cmd.split(" "), stdout=logfile, stderr=logfile)
         utils.print_message(type="info", message="waiting for db folder to be created")
         count = 0
         count_timeout = 299


### PR DESCRIPTION
This change prevents the logfile from being closed prematurely, ensuring proper logging of the node start command.