### PR TITLE
refactor: remove unnecessary json and ast conversions

### DIFF
--- a/sync_tests/tests/node_sync_test.py
+++ b/sync_tests/tests/node_sync_test.py
@@ -1036,7 +1036,7 @@ def run_test(args: argparse.Namespace) -> None:
     test_values_dict: dict[str, tp.Any] = {}
     print("--- Parse the node logs and get the relevant data")
     logs_details_dict = get_data_from_logs(log_file=base_dir / NODE_LOG_FILE_NAME)
-    test_values_dict["log_values"] = json.dumps(logs_details_dict)
+    test_values_dict["log_values"] = logs_details_dict
 
     sync2_rec = None
     print(f"--- Start node using tag_no2: {tag_no2}")
@@ -1126,8 +1126,8 @@ def run_test(args: argparse.Namespace) -> None:
     test_values_dict["platform_release"] = platform_release
     test_values_dict["platform_version"] = platform_version
     test_values_dict["chain_size_bytes"] = chain_size
-    test_values_dict["sync_duration_per_epoch"] = json.dumps(epoch_details)
-    test_values_dict["eras_in_test"] = json.dumps(list(sync1_rec.era_details.keys()))
+    test_values_dict["sync_duration_per_epoch"] = epoch_details
+    test_values_dict["eras_in_test"] = list(sync1_rec.era_details.keys())
     test_values_dict["no_of_cpu_cores"] = os.cpu_count()
     test_values_dict["total_ram_in_GB"] = helpers.get_total_ram_in_gb()
     test_values_dict["epoch_no_d_zero"] = get_epoch_no_d_zero(env=env)

--- a/sync_tests/tests/node_write_sync_values_to_db.py
+++ b/sync_tests/tests/node_write_sync_values_to_db.py
@@ -1,5 +1,4 @@
 import argparse
-import ast
 import json
 import logging
 import os
@@ -44,13 +43,7 @@ def main() -> None:
 
     utils.print_message(type="info", message="Check if there are DB columns for all the eras")
     print("Get the list of the existing eras in test")
-    eras_in_test = (
-        sync_test_results_dict["eras_in_test"]
-        .replace("[", "")
-        .replace("]", "")
-        .replace('"', "")
-        .split(", ")
-    )
+    eras_in_test = sync_test_results_dict["eras_in_test"]
     print(f"eras_in_test: {eras_in_test}")
 
     utils.print_message(type="info", message=f"Get the column names inside the {env} DB tables")
@@ -107,7 +100,7 @@ def main() -> None:
         type="info",
         message=f"  ==== Write test values into the {env + '_logs'} DB table",
     )
-    log_values_dict = ast.literal_eval(str(sync_test_results_dict["log_values"]))
+    log_values_dict = sync_test_results_dict["log_values"]
 
     df1_column_names = [
         "identifier",
@@ -144,9 +137,7 @@ def main() -> None:
         type="info",
         message=f"  ==== Write test values into the {env + '_epoch_duration'} DB table",
     )
-    sync_duration_values_dict = ast.literal_eval(
-        str(sync_test_results_dict["sync_duration_per_epoch"])
-    )
+    sync_duration_values_dict = sync_test_results_dict["sync_duration_per_epoch"]
     epoch_list = list(sync_duration_values_dict.keys())
 
     df2_column_names = ["identifier", "epoch_no", "sync_duration_secs"]


### PR DESCRIPTION
- Directly use dictionaries instead of converting to/from JSON
- Simplify era list extraction by removing string manipulation
- Remove unused ast import in node_write_sync_values_to_db.py