### PR TITLE
refactor: use binaries from environment

### DIFF
--- a/sync_tests/tests/full_sync_from_clean_state.py
+++ b/sync_tests/tests/full_sync_from_clean_state.py
@@ -24,7 +24,6 @@ sys.path.append(os.getcwd())
 TEST_RESULTS = f"db_sync_{db_sync.ENVIRONMENT}_full_sync_test_results.json"
 CHART = f"full_sync_{db_sync.ENVIRONMENT}_stats_chart.png"
 EXPECTED_DB_SCHEMA, EXPECTED_DB_INDEXES = helpers.load_json_files()
-NODE = pl.Path.cwd() / "cardano-node"
 
 
 def create_sync_stats_chart() -> None:
@@ -210,6 +209,9 @@ def main() -> None:
     # cardano-node setup
     conf_dir = pl.Path.cwd()
     base_dir = pl.Path.cwd()
+    bin_dir = pl.Path("bin")
+    bin_dir.mkdir(exist_ok=True)
+    node.add_to_path(path=bin_dir)
 
     node.set_node_socket_path_env_var(base_dir=base_dir)
     node.get_node_files(node_rev=node_version_from_gh_action)
@@ -223,7 +225,7 @@ def main() -> None:
         use_genesis_mode=False,
     )
     node.configure_node(config_file=conf_dir / "config.json")
-    node.start_node(cardano_node=NODE, base_dir=base_dir, node_start_arguments=())
+    node.start_node(base_dir=base_dir, node_start_arguments=())
     node.wait_node_start(env=env, timeout_minutes=10)
 
     print("--- Node startup", flush=True)

--- a/sync_tests/tests/iohk_snapshot_restoration.py
+++ b/sync_tests/tests/iohk_snapshot_restoration.py
@@ -20,7 +20,6 @@ from sync_tests.utils import node
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 TEST_RESULTS = "db_sync_iohk_snapshot_restoration_test_results.json"
-NODE = pl.Path.cwd() / "cardano-node"
 
 
 def upload_snapshot_restoration_results_to_aws(env: str) -> None:
@@ -79,9 +78,11 @@ def main() -> None:
     print(f"Snapshot url: {snapshot_url}")
 
     # cardano-node setup
-    # cardano-node setup
     conf_dir = pl.Path.cwd()
     base_dir = pl.Path.cwd()
+    bin_dir = pl.Path("bin")
+    bin_dir.mkdir(exist_ok=True)
+    node.add_to_path(path=bin_dir)
 
     node.set_node_socket_path_env_var(base_dir=base_dir)
     node.get_node_files(node_rev=node_version_from_gh_action)
@@ -95,7 +96,7 @@ def main() -> None:
         use_genesis_mode=False,
     )
     node.configure_node(config_file=conf_dir / "config.json")
-    node.start_node(cardano_node=NODE, base_dir=base_dir, node_start_arguments=())
+    node.start_node(base_dir=base_dir, node_start_arguments=())
     node.wait_node_start(env=env, timeout_minutes=10)
     print("--- Node startup", flush=True)
     db_sync.print_file(db_sync.NODE_LOG_FILE, 80)

--- a/sync_tests/tests/local_snapshot_restoration.py
+++ b/sync_tests/tests/local_snapshot_restoration.py
@@ -18,7 +18,6 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(
 
 TEST_RESULTS = f"db_sync_{db_sync.ENVIRONMENT}_local_snapshot_restoration_test_results.json"
 DB_SYNC_RESTORATION_ARCHIVE = f"cardano_db_sync_{db_sync.ENVIRONMENT}_restoration.zip"
-NODE = pl.Path.cwd() / "cardano-node"
 
 
 def main() -> int:
@@ -84,6 +83,9 @@ def main() -> int:
     # cardano-node setup
     conf_dir = pl.Path.cwd()
     base_dir = pl.Path.cwd()
+    bin_dir = pl.Path("bin")
+    bin_dir.mkdir(exist_ok=True)
+    node.add_to_path(path=bin_dir)
 
     node.set_node_socket_path_env_var(base_dir=base_dir)
     node.get_node_files(node_rev=node_version_from_gh_action)
@@ -97,7 +99,7 @@ def main() -> int:
         use_genesis_mode=False,
     )
     node.configure_node(config_file=conf_dir / "config.json")
-    node.start_node(cardano_node=NODE, base_dir=base_dir, node_start_arguments=())
+    node.start_node(base_dir=base_dir, node_start_arguments=())
     node.wait_node_start(env=env, timeout_minutes=10)
     db_sync.print_file(db_sync.NODE_LOG_FILE, 80)
     node.wait_for_node_to_sync(env=env, base_dir=base_dir)


### PR DESCRIPTION
- Removed hardcoded paths for cardano-node and cardano-cli binaries.
- Added function to dynamically add binary directory to PATH.
- Updated test scripts to use binaries from the environment.
- Ensured binary directory is created if it doesn't exist.
- Simplified node start command by removing redundant arguments.