### PR TITLE
feat(logging): extract color logger to separate module

### DIFF
--- a/sync_tests/tests/node_sync_test.py
+++ b/sync_tests/tests/node_sync_test.py
@@ -8,8 +8,7 @@ import shutil
 import sys
 import typing as tp
 
-import colorama
-
+from sync_tests.utils import color_logger
 from sync_tests.utils import helpers
 from sync_tests.utils import metrics_extractor
 from sync_tests.utils import node
@@ -18,33 +17,6 @@ LOGGER = logging.getLogger(__name__)
 
 NODE_LOG_FILE_ARTIFACT = "node.log"
 RESULTS_FILE_NAME = "sync_results.json"
-
-
-class ColorFormatter(logging.Formatter):
-    COLORS: tp.ClassVar[dict[str, str]] = {
-        "WARNING": colorama.Fore.YELLOW,
-        "ERROR": colorama.Fore.RED,
-        "DEBUG": colorama.Fore.BLUE,
-        # Keep "INFO" uncolored
-        "CRITICAL": colorama.Fore.RED,
-    }
-
-    def format(self, record: logging.LogRecord) -> str:
-        color: str | None = self.COLORS.get(record.levelname)
-        if color:
-            record.name = f"{color}{record.name}{colorama.Style.RESET_ALL}"
-            record.levelname = f"{color}{record.levelname}{colorama.Style.RESET_ALL}"
-            record.msg = f"{color}{record.msg}{colorama.Style.RESET_ALL}"
-        return super().format(record)
-
-
-class ColorLogger(logging.Logger):
-    def __init__(self, name: str) -> None:
-        super().__init__(name, logging.INFO)
-        color_formatter = ColorFormatter("%(message)s")
-        console = logging.StreamHandler()
-        console.setFormatter(color_formatter)
-        self.addHandler(console)
 
 
 def run_test(args: argparse.Namespace) -> None:
@@ -325,7 +297,7 @@ def get_args() -> argparse.Namespace:
 
 
 def main() -> int:
-    logging.setLoggerClass(ColorLogger)
+    logging.setLoggerClass(color_logger.ColorLogger)
     args = get_args()
     run_test(args=args)
 

--- a/sync_tests/utils/color_logger.py
+++ b/sync_tests/utils/color_logger.py
@@ -1,0 +1,36 @@
+import logging
+import typing as tp
+
+import colorama
+
+LOGGER = logging.getLogger(__name__)
+
+NODE_LOG_FILE_ARTIFACT = "node.log"
+RESULTS_FILE_NAME = "sync_results.json"
+
+
+class ColorFormatter(logging.Formatter):
+    COLORS: tp.ClassVar[dict[str, str]] = {
+        "WARNING": colorama.Fore.YELLOW,
+        "ERROR": colorama.Fore.RED,
+        "DEBUG": colorama.Fore.BLUE,
+        # Keep "INFO" uncolored
+        "CRITICAL": colorama.Fore.RED,
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        color: str | None = self.COLORS.get(record.levelname)
+        if color:
+            record.name = f"{color}{record.name}{colorama.Style.RESET_ALL}"
+            record.levelname = f"{color}{record.levelname}{colorama.Style.RESET_ALL}"
+            record.msg = f"{color}{record.msg}{colorama.Style.RESET_ALL}"
+        return super().format(record)
+
+
+class ColorLogger(logging.Logger):
+    def __init__(self, name: str) -> None:
+        super().__init__(name, logging.INFO)
+        color_formatter = ColorFormatter("%(message)s")
+        console = logging.StreamHandler()
+        console.setFormatter(color_formatter)
+        self.addHandler(console)


### PR DESCRIPTION
- Moved ColorLogger and ColorFormatter classes from node_sync_test.py to a new module color_logger.py
- Updated imports in node_sync_test.py to use the new color_logger module