### PR TITLE
refactor(utils): remove unused constants from color_logger

### DIFF
--- a/sync_tests/utils/color_logger.py
+++ b/sync_tests/utils/color_logger.py
@@ -3,11 +3,6 @@ import typing as tp
 
 import colorama
 
-LOGGER = logging.getLogger(__name__)
-
-NODE_LOG_FILE_ARTIFACT = "node.log"
-RESULTS_FILE_NAME = "sync_results.json"
-
 
 class ColorFormatter(logging.Formatter):
     COLORS: tp.ClassVar[dict[str, str]] = {


### PR DESCRIPTION
Removed LOGGER, NODE_LOG_FILE_ARTIFACT, and RESULTS_FILE_NAME constants from color_logger.py as they were no longer needed. This cleanup helps in maintaining a cleaner and more readable codebase.