### PR TITLE
refactor: remove build_mode from node sync tests

### DIFF
--- a/.github/workflows/node_sync_test.yaml
+++ b/.github/workflows/node_sync_test.yaml
@@ -11,12 +11,6 @@ on:
         - preprod
         - preview
         default: preprod
-      build_mode:
-        description: "build-mode"
-        type: choice
-        options:
-        - nix
-        default: nix
       tag_no1:
         description: "Initial sync - Graph axis label"
         required: true
@@ -97,7 +91,6 @@ jobs:
           BLOCKFROST_API_KEY: ${{ secrets.BLOCKFROST_API_KEY }}
           BUILD_ENV_VARS: '{
           "env":"${{ github.event.inputs.environment }}",
-          "build_mode":"${{ github.event.inputs.build_mode }}",
           "node_rev1":"${{ steps.get_tag.outputs.node_rev1 }}",
           "node_rev2":"${{ github.event.inputs.node_rev2 }}",
           "tag_no1":"${{ github.event.inputs.tag_no1 }}",

--- a/sync_tests/tests/node_sync_test.py
+++ b/sync_tests/tests/node_sync_test.py
@@ -30,7 +30,6 @@ def run_test(args: argparse.Namespace) -> None:
     helpers.print_message(type="info", message=f"Test start time: {start_test_time}")
     helpers.print_message(type="warn", message="Test parameters:")
     env = helpers.get_arg_value(args=args, key="environment")
-    node_build_mode = helpers.get_arg_value(args=args, key="build_mode") or "nix"
     node_rev1 = helpers.get_arg_value(args=args, key="node_rev1")
     node_rev2 = helpers.get_arg_value(args=args, key="node_rev2")
     tag_no1 = helpers.get_arg_value(args=args, key="tag_no1")
@@ -42,7 +41,6 @@ def run_test(args: argparse.Namespace) -> None:
     use_genesis_mode = helpers.get_arg_value(args=args, key="use_genesis_mode")
 
     print(f"- env: {env}")
-    print(f"- node_build_mode: {node_build_mode}")
     print(f"- tag_no1: {tag_no1}")
     print(f"- tag_no2: {tag_no2}")
     print(f"- node_rev1: {node_rev1}")
@@ -60,7 +58,6 @@ def run_test(args: argparse.Namespace) -> None:
     node.config_sync(
         env=env,
         conf_dir=conf_dir,
-        node_build_mode=node_build_mode,
         node_rev=node_rev1,
         node_topology_type=node_topology_type1,
         use_genesis_mode=use_genesis_mode,
@@ -129,7 +126,6 @@ def run_test(args: argparse.Namespace) -> None:
         node.config_sync(
             env=env,
             conf_dir=conf_dir,
-            node_build_mode=node_build_mode,
             node_rev=node_rev2,
             node_topology_type=node_topology_type2,
             use_genesis_mode=use_genesis_mode,
@@ -221,9 +217,6 @@ def get_args() -> argparse.Namespace:
     """Get command line arguments."""
     parser = argparse.ArgumentParser(description="Run Cardano Node sync test\n\n")
 
-    parser.add_argument(
-        "-b", "--build_mode", help="how to get the node files - nix, cabal, prebuilt"
-    )
     parser.add_argument(
         "-e",
         "--environment",

--- a/sync_tests/utils/node.py
+++ b/sync_tests/utils/node.py
@@ -672,12 +672,11 @@ def get_node_files(node_rev: str, build_tool: str = "nix") -> git.Repo:
 def config_sync(
     env: str,
     conf_dir: pl.Path,
-    node_build_mode: str,
     node_rev: str,
     node_topology_type: str,
     use_genesis_mode: bool,
 ) -> None:
-    LOGGER.info(f"Get the cardano-node and cardano-cli files using - {node_build_mode}")
+    LOGGER.info("Get the cardano-node and cardano-cli files")
     start_build_time = datetime.datetime.now(tz=datetime.timezone.utc).strftime("%d/%m/%Y %H:%M:%S")
 
     bin_dir = pl.Path("bin")
@@ -685,20 +684,16 @@ def config_sync(
     add_to_path(path=bin_dir)
 
     platform_system = platform.system().lower()
-    if "windows" not in platform_system:
-        get_node_files(node_rev)
-    elif "windows" in platform_system:
-        get_node_files(node_rev, build_tool="cabal")
+    if "windows" in platform_system:
+        get_node_files(node_rev=node_rev, build_tool="cabal")
     else:
-        err = f"Only building with NIX is supported at this moment - {node_build_mode}"
-        raise exceptions.SyncError(err)
+        get_node_files(node_rev=node_rev)
 
     end_build_time = datetime.datetime.now(tz=datetime.timezone.utc).strftime("%d/%m/%Y %H:%M:%S")
     LOGGER.info(f"  - start_build_time: {start_build_time}")
     LOGGER.info(f"  - end_build_time: {end_build_time}")
 
     rm_node_config_files(conf_dir=conf_dir)
-    # TODO: change the default to P2P when full P2P will be supported on Mainnet
     get_node_config_files(
         env=env,
         node_topology_type=node_topology_type,


### PR DESCRIPTION
This commit removes the build_mode parameter from the node sync tests.

Nix is always used on Linux and MacOS and cabal on Windows. There's no need to specify the build mode.

The changes include:
- Removing build_mode input from GitHub workflow
- Removing build_mode argument from node_sync_test.py
- Updating config_sync function in node.py to exclude build_mode

These changes simplify the configuration and reduce unnecessary complexity in the codebase.