### PR TITLE
feat(sync): raise SyncError instead of RuntimeError

### DIFF
--- a/sync_tests/utils/node.py
+++ b/sync_tests/utils/node.py
@@ -230,7 +230,7 @@ def get_node_version() -> tuple[str, str]:
         msg = "command '{}' return with error (code {}): {}".format(
             e.cmd, e.returncode, " ".join(str(e.output).split())
         )
-        raise RuntimeError(msg) from e
+        raise exceptions.SyncError(msg) from e
 
 
 def start_node(


### PR DESCRIPTION
Updated the get_node_version function to raise a SyncError instead of RuntimeError when a command fails. This change improves error handling specificity and aligns with the custom exception handling strategy.