### PR TITLE
fix(logging): update logging configuration

### DIFF
--- a/sync_tests/tests/node_sync_test.py
+++ b/sync_tests/tests/node_sync_test.py
@@ -318,7 +318,7 @@ def get_args() -> argparse.Namespace:
 
 
 def main() -> int:
-    logging.setLoggerClass(color_logger.ColorLogger)
+    color_logger.configure_logging()
     args = get_args()
     run_test(args=args)
 

--- a/sync_tests/utils/color_logger.py
+++ b/sync_tests/utils/color_logger.py
@@ -22,10 +22,16 @@ class ColorFormatter(logging.Formatter):
         return super().format(record)
 
 
-class ColorLogger(logging.Logger):
-    def __init__(self, name: str) -> None:
-        super().__init__(name, logging.INFO)
-        color_formatter = ColorFormatter("%(message)s")
-        console = logging.StreamHandler()
-        console.setFormatter(color_formatter)
-        self.addHandler(console)
+def configure_logging(fmt: str | None = None) -> None:
+    fmt = fmt or "%(message)s"
+    logging.setLoggerClass(logging.Logger)  # Ensure standard logger is used
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)  # Set the global log level
+
+    # Remove existing handlers to avoid duplicates
+    while root_logger.handlers:
+        root_logger.handlers.pop()
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(ColorFormatter(fmt))
+    root_logger.addHandler(console_handler)


### PR DESCRIPTION
Refactor logging setup to use a configuration function instead of a custom logger class. This change ensures the standard logger is used and removes existing handlers to avoid duplicates.

- Replaced `ColorLogger` with `configure_logging` function
- Updated `node_sync_test.py` to use the new logging configuration