### PR TITLE
feat(nix): add IOG cache and trusted keys to flake config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,4 +53,12 @@
             };
           };
         });
+
+  # --- Flake Local Nix Configuration ----------------------------
+  nixConfig = {
+    # Sets the flake to use the IOG nix cache.
+    extra-substituters = [ "https://cache.iog.io" ];
+    extra-trusted-public-keys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
+    allow-import-from-derivation = "true";
+  };
 }


### PR DESCRIPTION
Added local nixConfig to flake.nix to use the IOG cache and trusted public keys for improved build performance. Enabled allow-import-from-derivation for compatibility with certain derivations.