### PR TITLE
feat(ci): update Buildkite trigger to use 'with' syntax

### DIFF
--- a/.github/workflows/node_sync_test.yaml
+++ b/.github/workflows/node_sync_test.yaml
@@ -83,30 +83,29 @@ jobs:
 
       - name: Trigger the Buildkite pipeline - run sync tests on Mainnet
         uses: 'buildkite/trigger-pipeline-action@v2.3.0'
-        env:
-          BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.BUILDKITE_API_ACCESS_TOKEN }}
-          PIPELINE: 'input-output-hk/node-sync-tests'
-          BRANCH: ${{ github.ref_name }}
-          MESSAGE: ':github: Triggered by GitHub Action'
-          AWS_DB_USERNAME: ${{ secrets.AWS_DB_USERNAME }}
-          AWS_DB_PASS: ${{ secrets.AWS_DB_PASS }}
-          AWS_DB_NAME: ${{ secrets.AWS_DB_NAME }}
-          AWS_DB_HOSTNAME: ${{ secrets.AWS_DB_HOSTNAME }}
-          BLOCKFROST_API_KEY: ${{ secrets.BLOCKFROST_API_KEY }}
-          BUILD_ENV_VARS: '{
-          "env":"${{ github.event.inputs.environment }}",
-          "node_rev1":"${{ steps.get_tag.outputs.node_rev1 }}",
-          "node_rev2":"${{ github.event.inputs.node_rev2 }}",
-          "tag_no1":"${{ github.event.inputs.tag_no1 }}",
-          "tag_no2":"${{ github.event.inputs.tag_no2 }}",
-          "node_topology1":"${{ github.event.inputs.node_topology1 }}",
-          "node_topology2":"${{ github.event.inputs.node_topology2 }}",
-          "node_start_arguments1":"${{ github.event.inputs.node_start_arguments1 }}",
-          "node_start_arguments2":"${{ github.event.inputs.node_start_arguments2 }}",
-          "use_genesis_mode":"${{ github.event.inputs.use_genesis_mode }}",
-          "BLOCKFROST_API_KEY":"${{ secrets.BLOCKFROST_API_KEY }}",
-          "AWS_DB_USERNAME":"${{ secrets.AWS_DB_USERNAME }}",
-          "AWS_DB_PASS":"${{ secrets.AWS_DB_PASS }}",
-          "AWS_DB_NAME":"${{ secrets.AWS_DB_NAME }}",
-          "AWS_DB_HOSTNAME":"${{ secrets.AWS_DB_HOSTNAME }}"
-          }'
+        with:
+          buildkite_api_access_token: ${{ secrets.BUILDKITE_API_ACCESS_TOKEN }}
+          pipeline: 'input-output-hk/node-sync-tests'
+          branch: ${{ github.ref_name || 'main' }}
+          message: ':github: Triggered by GitHub Action'
+          build_env_vars: |
+            {
+              "env": "${{ github.event.inputs.environment }}",
+              "node_rev1": "${{ steps.get_tag.outputs.node_rev1 }}",
+              "node_rev2": "${{ github.event.inputs.node_rev2 }}",
+              "tag_no1": "${{ github.event.inputs.tag_no1 }}",
+              "tag_no2": "${{ github.event.inputs.tag_no2 }}",
+              "node_topology1": "${{ github.event.inputs.node_topology1 }}",
+              "node_topology2": "${{ github.event.inputs.node_topology2 }}",
+              "node_start_arguments1": "${{ github.event.inputs.node_start_arguments1 }}",
+              "node_start_arguments2": "${{ github.event.inputs.node_start_arguments2 }}",
+              "use_genesis_mode": "${{ github.event.inputs.use_genesis_mode }}",
+              "BLOCKFROST_API_KEY": "${{ secrets.BLOCKFROST_API_KEY }}",
+              "AWS_DB_USERNAME": "${{ secrets.AWS_DB_USERNAME }}",
+              "AWS_DB_PASS": "${{ secrets.AWS_DB_PASS }}",
+              "AWS_DB_NAME": "${{ secrets.AWS_DB_NAME }}",
+              "AWS_DB_HOSTNAME": "${{ secrets.AWS_DB_HOSTNAME }}"
+            }
+
+      - name: Finalize sync
+        run: echo "Sync job finished."


### PR DESCRIPTION
Refactor Buildkite pipeline trigger step in node_sync_test workflow to use the 'with' syntax instead of 'env'. This improves readability and aligns with recommended usage for the buildkite/trigger-pipeline-action. Also formats build environment variables as a YAML block for clarity.