### PR TITLE
feat(graphs): switch to matplotlib/seaborn for static plots

### DIFF
--- a/.buildkite/node_sync_tests.yml
+++ b/.buildkite/node_sync_tests.yml
@@ -16,4 +16,4 @@ steps:
     artifact_paths:
       - 'logfile.log'
       - 'sync_results.json'
-      - 'sync_data_backup.json' 
+      - 'sync_data_backup.json'

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,3 +33,4 @@ install_requires =
     requests
     setuptools >= 60.5.0
     xmltodict
+    seaborn

--- a/sync_tests/tests/full_sync_from_clean_state.py
+++ b/sync_tests/tests/full_sync_from_clean_state.py
@@ -198,17 +198,13 @@ def get_args() -> argparse.Namespace:
         "-nv",
         "--node-revision",
         required=True,
-        help=(
-            "Desired cardano-node revision - cardano-node tag or branch"
-        ),
+        help=("Desired cardano-node revision - cardano-node tag or branch"),
     )
     parser.add_argument(
         "-dv",
         "--db-sync-revision",
         required=True,
-        help=(
-            "Desired db-sync revision - db-sync tag or branch"
-        ),
+        help=("Desired db-sync revision - db-sync tag or branch"),
     )
     parser.add_argument(
         "-dsa",

--- a/sync_tests/utils/node.py
+++ b/sync_tests/utils/node.py
@@ -120,8 +120,7 @@ def get_node_config_files(
 
     try:
         download_config_file(
-            config_slug=f"{env}/checkpoints.json",
-            save_as=conf_dir / "checkpoints.json"
+            config_slug=f"{env}/checkpoints.json", save_as=conf_dir / "checkpoints.json"
         )
     except Exception:
         LOGGER.warning("checkpoints.json file not available")

--- a/sync_tests/utils/sync_static_graphs.py
+++ b/sync_tests/utils/sync_static_graphs.py
@@ -1,19 +1,22 @@
+#!/usr/bin/env python3
+
 import argparse
 import ast
 import json
 import logging
-import os
+import pathlib as pl
 import sys
 
-import plotly.express as px
-import plotly.graph_objects as go
+import matplotlib.pyplot as plt
+import numpy as np
+import seaborn as sns
+from matplotlib import ticker
 
-COLORS = px.colors.qualitative.Plotly
+sns.set_theme(style="whitegrid")
 LOGGER = logging.getLogger(__name__)
 
 
 def get_args() -> argparse.Namespace:
-    """Get command line arguments."""
     parser = argparse.ArgumentParser(description="Generate sync tests result graphs.")
     parser.add_argument(
         "-i",
@@ -24,209 +27,172 @@ def get_args() -> argparse.Namespace:
         help="List of JSON file paths to process.",
     )
     parser.add_argument(
-        "-o",
-        "--output-dir",
-        required=False,
-        help="Output directory, assume cwd if not provided",
+        "-o", "--output-dir", required=False, help="Output directory, assume cwd if not provided"
     )
-
+    parser.add_argument("--dpi", type=int, default=150, help="DPI for output images (default: 150)")
+    parser.add_argument("--format", type=str, default="png", help="Image format (png, pdf, svg...)")
     return parser.parse_args()
 
 
-def generate_static_graphs(file_list: list, output_dir: str = "") -> None:
-    """Process a list of JSON files, loading their content and generate sync graphs."""
+def generate_static_graphs(
+    file_list: list[str],
+    output_dir: str,
+    dpi: int,
+    fmt: str,
+) -> None:
     LOGGER.info("Starting the sync report generation.")
 
     eras = ["byron", "shelley", "allegra", "mary", "alonzo", "babbage", "conway"]
-
     log_data = {}
     sync_duration_data = {}
     sync_time_data = {}
 
-    for file_path in file_list:
-        if not os.path.exists(file_path):
+    output_path = pl.Path(output_dir or ".")
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    for file_path_str in file_list:
+        file_path = pl.Path(file_path_str)
+        if not file_path.exists():
             LOGGER.error(f"File not found: {file_path}")
             continue
 
         LOGGER.info(f"Processing file: {file_path}")
 
         try:
-            with open(file_path, encoding="utf-8") as file:
+            with file_path.open(encoding="utf-8") as file:
                 sync_results = json.load(file)
-                dataset_name = os.path.basename(file_path)
+                dataset_name = file_path.name
 
-                # Resources consumption
                 log_values_dict = ast.literal_eval(str(sync_results["log_values"]))
                 log_data[dataset_name] = dict(
                     sorted(log_values_dict.items(), key=lambda item: str(item[0]))
                 )
 
-                # Sync duration per epoch
                 sync_duration_dict = ast.literal_eval(str(sync_results["sync_duration_per_epoch"]))
                 sync_duration_data[dataset_name] = sync_duration_dict
 
-                # Sync time per Era
-                sync_time_per_era = {}
-                for era in eras:
-                    sync_time_per_era[era] = sync_results.get(f"{era}_sync_duration_secs", 0)
+                sync_time_per_era = {
+                    era: sync_results.get(f"{era}_sync_duration_secs", 0) for era in eras
+                }
                 sync_time_data[dataset_name] = sync_time_per_era
 
-                LOGGER.info(f"Successfully loaded JSON data from {file_path}.")
         except Exception:
             LOGGER.exception(f"Unexpected error with file {file_path}")
 
     LOGGER.info("Generating sync results graphs.")
-    generate_resource_consumption_graphs(datasets=log_data, output_dir=output_dir)
-    generate_duration_per_epoch_graphs(datasets=sync_duration_data, output_dir=output_dir)
-    generate_sync_time_per_era_graphs(datasets=sync_time_data, eras=eras, output_dir=output_dir)
+    generate_resource_consumption_graphs(log_data, output_path, dpi=dpi, fmt=fmt)
+    generate_duration_per_epoch_graphs(sync_duration_data, output_path, dpi=dpi, fmt=fmt)
+    generate_sync_time_per_era_graphs(sync_time_data, eras, output_path, dpi=dpi, fmt=fmt)
 
 
-def generate_resource_consumption_graphs(datasets: dict, output_dir: str) -> None:
-    """Generate graphs related to resource consumption during sync."""
-    # Figures for RSS, RAM, and CPU
-    fig_rss = go.Figure()
-    fig_ram = go.Figure()
-    fig_cpu = go.Figure()
+def generate_resource_consumption_graphs(
+    datasets: dict[str, dict],
+    output_dir: pl.Path,
+    dpi: int,
+    fmt: str,
+) -> None:
+    palette = sns.color_palette("tab10")
 
-    # Helper function to process data and add traces
-    def _add_traces(fig: go.Figure, data_type: str, unit_conversion: int = 1) -> None:
+    def _plot(
+        data_type: str, unit_conversion: float, title: str, ylabel: str, basename: str
+    ) -> None:
+        plt.figure(figsize=(8, 6))
         for idx, (dataset_name, data) in enumerate(datasets.items()):
-            resource_data = {}
-
+            x = []
+            y = []
             for value in data.values():
-                if value["tip"] and value[data_type] and float(value[data_type]) > 0:
-                    resource_data[int(value["tip"])] = float(value[data_type]) / unit_conversion
+                if value.get("tip") and value.get(data_type):
+                    raw = float(value[data_type])
+                    if raw > 0:
+                        x.append(int(value["tip"]))
+                        y.append(raw / unit_conversion)
+            plt.plot(x, y, label=dataset_name, color=palette[idx % len(palette)])
 
-            fig.add_trace(
-                go.Scatter(
-                    x=list(resource_data.keys()),
-                    y=list(resource_data.values()),
-                    mode="lines",
-                    name=dataset_name,
-                    line={"color": COLORS[idx]},
-                )
-            )
+        plt.title(title)
+        plt.xlabel("Slot Number")
+        plt.ylabel(ylabel)
+        plt.legend()
+        plt.tight_layout()
+        plt.savefig(output_dir / f"{basename}.{fmt}", dpi=dpi, format=fmt)
+        plt.close()
 
-    # Add traces for each graph
-    _add_traces(fig=fig_rss, data_type="rss_ram", unit_conversion=1024**3)
-    _add_traces(fig=fig_ram, data_type="heap_ram", unit_conversion=1024**3)
-    _add_traces(fig=fig_cpu, data_type="cpu")
-
-    # Update layouts
-    fig_rss.update_layout(
-        title="RSS Consumption",
-        xaxis_title="Slot Number",
-        yaxis_title="RSS consumed [GB]",
-        width=800,
-        height=600,
-    )
-
-    fig_ram.update_layout(
-        title="RAM Consumption",
-        xaxis_title="Slot Number",
-        yaxis_title="RAM consumed [GB]",
-        width=800,
-        height=600,
-    )
-
-    fig_cpu.update_layout(
-        title="CPU load",
-        xaxis_title="Slot Number",
-        yaxis_title="CPU consumed [%]",
-        width=800,
-        height=600,
-    )
-
-    # Save the graphs
-    fig_rss.write_image(os.path.join(output_dir, "sync_rss_consumption.png"))
-    fig_ram.write_image(os.path.join(output_dir, "sync_ram_consumption.png"))
-    fig_cpu.write_image(os.path.join(output_dir, "sync_cpu_consumption.png"))
-
+    _plot("rss_ram", 1024**3, "RSS Consumption", "RSS consumed [GB]", "sync_rss_consumption")
+    _plot("heap_ram", 1024**3, "RAM Consumption", "RAM consumed [GB]", "sync_ram_consumption")
+    _plot("cpu", 1, "CPU Load", "CPU consumed [%]", "sync_cpu_consumption")
     LOGGER.info("Successfully generated sync resource consumption graphs.")
 
 
-def generate_duration_per_epoch_graphs(datasets: dict, output_dir: str) -> None:
-    """Generate graphs related to sync duration per epoch."""
-    fig_duration_per_epoch = go.Figure()
+def generate_duration_per_epoch_graphs(
+    datasets: dict[str, dict],
+    output_dir: pl.Path,
+    dpi: int,
+    fmt: str,
+) -> None:
+    plt.figure(figsize=(8, 6))
+    palette = sns.color_palette("tab10")
 
-    # Add traces for each dataset
     for idx, (dataset_name, data) in enumerate(datasets.items()):
-        fig_duration_per_epoch.add_trace(
-            go.Scatter(
-                x=list(data.keys()),  # Epoch numbers
-                y=list(data.values()),  # Sync durations
-                mode="lines",
-                name=dataset_name,
-                line={"color": COLORS[idx]},
-            )
-        )
+        x = list(map(int, data.keys()))
+        y = list(map(float, data.values()))
+        plt.plot(x, y, label=dataset_name, color=palette[idx % len(palette)])
 
-    # Update layout for better readability
-    fig_duration_per_epoch.update_layout(
-        title="Sync Duration per Epoch",
-        xaxis_title="Epoch Number",
-        yaxis_title="Sync duration [seconds]",
-        width=800,
-        height=600,
-    )
+    plt.title("Sync Duration per Epoch")
+    plt.xlabel("Epoch Number")
+    plt.ylabel("Sync duration [seconds]")
+    plt.legend()
 
-    # Save the graph
-    fig_duration_per_epoch.write_image(os.path.join(output_dir, "sync_duration_per_epoch.png"))
+    ax = plt.gca()
+    ax.xaxis.set_major_locator(ticker.MultipleLocator(50))  # Set x-ticks every 50
 
+    plt.tight_layout()
+    plt.savefig(output_dir / f"sync_duration_per_epoch.{fmt}", dpi=dpi, format=fmt)
+    plt.close()
     LOGGER.info("Successfully generated duration per epoch graph.")
 
 
-def generate_sync_time_per_era_graphs(datasets: dict, eras: list, output_dir: str) -> None:
-    """Generate a bar graph showing sync duration per era for different datasets."""
-    datasets_names = list(datasets.keys())
-    fig_time_per_era = go.Figure()
+def generate_sync_time_per_era_graphs(
+    datasets: dict[str, dict],
+    eras: list[str],
+    output_dir: pl.Path,
+    dpi: int,
+    fmt: str,
+) -> None:
+    dataset_names = list(datasets.keys())
+    values_per_era = [[datasets[name][era] for name in dataset_names] for era in eras]
 
-    # Add a bar for each era
-    for era in eras:
-        era_values = [data[era] for data in datasets.values()]
-        fig_time_per_era.add_trace(
-            go.Bar(
-                x=datasets_names,
-                y=era_values,
-                name=era,
-            )
-        )
+    ind = np.arange(len(dataset_names))
+    width = 0.6
+    bottoms = np.zeros(len(dataset_names))
+    palette = sns.color_palette("pastel", n_colors=len(eras))
 
-    # Calculate totals for each dataset
-    totals = [sum(data.values()) for data in datasets.values()]
+    plt.figure(figsize=(8, 6))
+    for idx, era in enumerate(eras):
+        values = values_per_era[idx]
+        plt.bar(ind, values, width, bottom=bottoms, label=era, color=palette[idx])
+        bottoms += values
 
-    # Add annotations for totals above each stacked bar
-    for i, total in enumerate(totals):
-        fig_time_per_era.add_annotation(
-            x=datasets_names[i],
-            y=total,
-            text=f"{total / 1000:.3f}K",
-            showarrow=False,
-            font={"size": 12, "color": "black"},
-            yshift=10,
-        )
+    for i, total in enumerate(bottoms):
+        plt.text(ind[i], total + 5, f"{total / 1000:.3f}K", ha="center", va="bottom", fontsize=9)
 
-    # Update layout for better readability
-    fig_time_per_era.update_layout(
-        title="Sync duration per era",
-        yaxis_title="Sync duration [seconds]",
-        barmode="stack",
-        width=800,
-        height=600,
-    )
-
-    # Save the graph
-    fig_time_per_era.write_image(os.path.join(output_dir, "sync_time_per_era.png"))
-
-    LOGGER.debug("Successfully generated sync time per era graph.")
+    plt.xticks(ind, dataset_names, rotation=45, ha="right")
+    plt.title("Sync Duration per Era")
+    plt.ylabel("Sync duration [seconds]")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(output_dir / f"sync_time_per_era.{fmt}", dpi=dpi, format=fmt)
+    plt.close()
+    LOGGER.info("Successfully generated sync time per era graph.")
 
 
 def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     args = get_args()
-
-    generate_static_graphs(file_list=args.json_files, output_dir=args.output_dir or "")
-
+    generate_static_graphs(
+        file_list=args.json_files,
+        output_dir=args.output_dir or "",
+        dpi=args.dpi,
+        fmt=args.format,
+    )
     return 0
 
 


### PR DESCRIPTION
Replace Plotly with matplotlib, seaborn, and numpy for generating static sync test result graphs. Add support for configurable DPI and output format. Refactor resource, epoch, and era graph generation to use new libraries and improve output directory handling. Update dependencies to include seaborn.

Plotly requires full google chrome browser, which is problematic on servers or remotely accessed machines.