### PR TITLE
Clone cardano-node and cardano-db-sync from IntersectMBO

### DIFF
--- a/sync_tests/utils/configuration.py
+++ b/sync_tests/utils/configuration.py
@@ -20,3 +20,7 @@ import typing as tp
 CONFIGS_BASE_URL: tp.Final[str] = (
     os.environ.get("CONFIGS_BASE_URL") or "https://book.world.dev.cardano.org/environments"
 )
+
+#: GitHub org that cardano-node and cardano-db-sync are cloned from.
+#: Override via the ``CARDANO_GITHUB_ORG`` environment variable.
+CARDANO_GITHUB_ORG: tp.Final[str] = os.environ.get("CARDANO_GITHUB_ORG") or "IntersectMBO"

--- a/sync_tests/utils/external/gitpython.py
+++ b/sync_tests/utils/external/gitpython.py
@@ -1,4 +1,4 @@
-"""Git utilities for cloning and checking out IOHK repositories."""
+"""Git utilities for cloning and checking out Cardano repositories."""
 
 from __future__ import annotations
 
@@ -8,6 +8,8 @@ import pathlib as pl
 
 from git import Repo
 from git.exc import GitCommandError
+
+from sync_tests.utils.configuration import CARDANO_GITHUB_ORG
 
 LOGGER = logging.getLogger(__name__)
 
@@ -29,9 +31,9 @@ def _fetch_updates(repo: Repo) -> None:
 
 
 def git_clone_iohk_repo(repo_name: str, repo_dir: pl.Path, repo_branch: str) -> Repo:
-    """Clones an IOHK repository and checks out a specific branch."""
+    """Clones a Cardano repository and checks out a specific branch."""
     try:
-        repo = Repo.clone_from(f"https://github.com/input-output-hk/{repo_name}.git", repo_dir)
+        repo = Repo.clone_from(f"https://github.com/{CARDANO_GITHUB_ORG}/{repo_name}.git", repo_dir)
         repo.git.checkout(repo_branch)
         LOGGER.info(
             "Repository %s successfully cloned to %s and branch %s checked out.",
@@ -84,7 +86,7 @@ def clone_repo(repo_name: str, repo_branch: str) -> str:
         return location
 
     try:
-        repo = Repo.clone_from(f"https://github.com/input-output-hk/{repo_name}.git", location)
+        repo = Repo.clone_from(f"https://github.com/{CARDANO_GITHUB_ORG}/{repo_name}.git", location)
         git_checkout(repo, repo_branch)
         LOGGER.info("Repository %s successfully cloned to %s.", repo_name, location)
     except GitCommandError:


### PR DESCRIPTION
## Summary
- gitpython.py hardcoded https://github.com/input-output-hk/{repo_name}.git for cloning cardano-node and cardano-db-sync
- pyproject.toml already lists this project's home as github.com/IntersectMBO/cardano-sync-tests, confirming the org rename already happened for this ecosystem
- It only kept working because GitHub redirects the old org to the new one; that redirect is not a guarantee
- Added a CARDANO_GITHUB_ORG constant in configuration.py (same override-via-env-var pattern already used for CONFIGS_BASE_URL), defaulting to IntersectMBO, and pointed both clone call sites at it

## Test plan
- [x] ruff, mypy, pre-commit all pass on the changed files
- [x] Local fast unit tests pass (test_disk_cleanup.py, test_ci_step_emit.py)
- [ ] Full local node sync test against preview (node revision 11.0.1)
- [ ] Full local db-sync test against preview (db-sync revision 13.7.2.1)
- [ ] Confirm sync_static_graphs.py can still generate graphs from the resulting results.json files

Sync test validation in progress, will update this PR with results.