### PR TITLE
Build start_node argv as a list instead of splitting a string

### DIFF
--- a/sync_tests/tests/test_start_node.py
+++ b/sync_tests/tests/test_start_node.py
@@ -1,0 +1,39 @@
+"""Regression test for start_node() building an argv list instead of a split string."""
+
+from __future__ import annotations
+
+import pathlib as pl
+import subprocess
+import typing as tp
+
+import pytest
+
+from sync_tests.utils import node
+
+
+def test_start_node_handles_paths_with_spaces(
+    tmp_path: pl.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A path containing a space must survive as a single argv element."""
+    base_dir = tmp_path / "node base dir"
+    conf_dir = tmp_path / "conf dir with spaces"
+    socket_path = tmp_path / "socket dir with spaces" / "node.socket"
+    monkeypatch.setenv("CARDANO_NODE_SOCKET_PATH", str(socket_path))
+    monkeypatch.setattr(node.helpers, "manage_process", lambda *_args, **_kwargs: None)
+
+    captured: dict[str, tp.Any] = {}
+
+    class _FakePopen:
+        def __init__(self, cmd: list[str], **_kwargs: tp.Any) -> None:
+            captured["cmd"] = cmd
+
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+
+    node.start_node(base_dir=base_dir, node_start_arguments=(), conf_dir=conf_dir)
+
+    cmd = captured["cmd"]
+    assert isinstance(cmd, list)
+    assert str(conf_dir / "topology.json") in cmd
+    assert str(base_dir / "db") in cmd
+    assert str(socket_path) in cmd
+    assert str(conf_dir / "config.json") in cmd

--- a/sync_tests/utils/node/__init__.py
+++ b/sync_tests/utils/node/__init__.py
@@ -508,17 +508,23 @@ def start_node(
     socket_path_p.unlink(missing_ok=True)
 
     effective_conf_dir = conf_dir if conf_dir is not None else pl.Path.cwd()
-    start_args = " ".join(node_start_arguments)
-    cmd = (
-        "cardano-node run "
-        f"--topology {effective_conf_dir / 'topology.json'} "
-        f"--database-path {base_dir / 'db'} "
-        f"--socket-path {socket_path} "
-        f"--config {effective_conf_dir / 'config.json'} "
-        "--host-addr 0.0.0.0 "
-        "--port 3000 "
-        f"{start_args}"
-    ).strip()
+    cmd = [
+        "cardano-node",
+        "run",
+        "--topology",
+        str(effective_conf_dir / "topology.json"),
+        "--database-path",
+        str(base_dir / "db"),
+        "--socket-path",
+        str(socket_path),
+        "--config",
+        str(effective_conf_dir / "config.json"),
+        "--host-addr",
+        "0.0.0.0",
+        "--port",
+        "3000",
+        *node_start_arguments,
+    ]
 
     LOGGER.info("Starting node with cmd: %s", cmd)
     # Ensure logfile is cleared/truncated before starting node
@@ -529,7 +535,7 @@ def start_node(
     logfile = open(logfile_path, "w+")
     LOGGER.info("Node logfile opened: %s (will write node output here)", logfile_path)
 
-    proc = subprocess.Popen(cmd.split(" "), stdout=logfile, stderr=logfile)
+    proc = subprocess.Popen(cmd, stdout=logfile, stderr=logfile)
     return proc, logfile
 
 


### PR DESCRIPTION
## Summary
- start_node() built the cardano-node launch command as one joined string and called cmd.split(" ") to get argv
- Any interpolated path (base_dir, conf_dir, socket_path) containing a space would silently corrupt the argv list instead of failing loudly
- Builds the argv list directly now and passes it straight to subprocess.Popen, no join/split round trip
- Added sync_tests/tests/test_start_node.py, a regression test with paths that contain spaces, asserting each survives as a single argv element

## Test plan
- [x] ruff, mypy, pre-commit all pass on the changed files
- [x] New unit test (test_start_node.py) passes locally
- [x] Local fast unit tests still pass (test_disk_cleanup.py, test_ci_step_emit.py)
- [ ] Full local node sync test against preview (node revision 11.0.1), since this is the exact code path being changed
- [ ] Confirm sync_static_graphs.py can still generate graphs from the resulting results.json

Sync test validation in progress, will update this PR with results.