### PR TITLE
Make run_only_sync_test actually gate snapshot tests

### DIFF
--- a/.github/workflows/db_sync_full_sync.yaml
+++ b/.github/workflows/db_sync_full_sync.yaml
@@ -93,9 +93,15 @@ jobs:
           HB_PID=$!
           trap 'pkill -P "$HB_PID" 2>/dev/null || true; kill "$HB_PID" 2>/dev/null || true' EXIT
 
+          if [ "${{ inputs.run_only_sync_test }}" = "true" ]; then
+            test_marker="node_sync or db_sync"
+          else
+            test_marker="node_sync or db_sync or snapshot_creation or local_snapshot"
+          fi
+
           pytest_args=(
             sync_tests/tests/
-            -m "node_sync or db_sync"
+            -m "${test_marker}"
             --environment "${{ inputs.environment }}"
             --node-revision "${{ inputs.node_version }}"
             --db-sync-revision "${{ inputs.db_sync_version }}"


### PR DESCRIPTION
## Summary
- db_sync_full_sync.yaml hardcoded -m "node_sync or db_sync" regardless of the run_only_sync_test input, so setting it to false never actually ran test_snapshot_creation.py / test_local_snapshot_restoration.py, contradicting the input's own description ("otherwise local snapshot creation and restoration tests will be started after sync test is completed")
- The pytest marker expression now depends on the toggle: true keeps the existing node_sync/db_sync-only filter, false widens it to include snapshot_creation and local_snapshot too
- test_iohk_snapshot_restoration.py (iohk_snapshot marker) is intentionally left out of this workflow, since it needs a --snapshot-url and downloads an official mainnet snapshot; it is a separate concern from what this input describes

## Test plan
- [x] YAML validated (python yaml.safe_load, pre-commit check-yaml)
- [x] Verified the fix directly with pytest --collect-only for both toggle states:
  - run_only_sync_test=true equivalent: 10/30 tests collected
  - run_only_sync_test=false equivalent: 15/30 tests collected, picking up exactly the snapshot creation and local restoration tests
- [ ] No node/db-sync sync-test run needed beyond the collection proof above, since this change only affects which tests get selected, not sync behavior itself