### PR TITLE
Generate performance graphs automatically before CI bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,12 @@ post-sync test durations are excluded from measured sync time.
 
 ## Graph Generation
 
-Generate performance graphs from sync test results using `sync_static_graphs.py`:
+In CI, graphs are generated automatically from `node_sync_results.json` /
+`db_sync_results.json` right before the `sync_results.zip` bundle is built, so
+the uploaded artifact bundle already contains them; graph generation failures
+are logged but never fail the test run. To generate graphs from a local run
+(or regenerate them from an old results file), run `sync_static_graphs.py`
+directly:
 
 ### Node-sync graphs
 

--- a/sync_tests/tests/test_dbsync_artifacts.py
+++ b/sync_tests/tests/test_dbsync_artifacts.py
@@ -163,8 +163,14 @@ class TestDbSyncArtifacts:
             (config.workdir / "cardano-db-sync").glob("*.json")
         )
 
-        # Include graphs if they exist
-        graphs_dir = config.workdir / "graphs"
+        # Generate db-sync graphs, and node graphs too if this is a combined run,
+        # then include them
+        graphs_dir = artifacts.generate_result_graphs(
+            config.workdir, [test_results_file], mode="dbsync"
+        )
+        node_results_file = config.workdir / "node_sync_results.json"
+        if node_results_file.exists():
+            artifacts.generate_result_graphs(config.workdir, [node_results_file], mode="node")
         graph_files = sorted(graphs_dir.glob("*.png")) if graphs_dir.exists() else []
 
         assert log_files, f"No log files found for CI bundling in {config.workdir}"

--- a/sync_tests/tests/test_nodesync_artifacts.py
+++ b/sync_tests/tests/test_nodesync_artifacts.py
@@ -337,8 +337,8 @@ class TestNodeSyncArtifacts:
         results_files = sorted(workdir.glob("*.json"))
         results_file = workdir / "node_sync_results.json"
 
-        # Include graphs if they exist
-        graphs_dir = workdir / "graphs"
+        # Generate graphs from the results we just wrote, then include them
+        graphs_dir = artifacts.generate_result_graphs(workdir, [results_file], mode="node")
         graph_files = sorted(graphs_dir.glob("*.png")) if graphs_dir.exists() else []
 
         assert log_files, f"No log files found for CI bundling in {workdir}"

--- a/sync_tests/utils/artifacts/__init__.py
+++ b/sync_tests/utils/artifacts/__init__.py
@@ -7,12 +7,47 @@ import os
 import pathlib as pl
 import shutil
 
+from sync_tests.scripts.sync_static_graphs import generate_static_graphs
 from sync_tests.utils import helpers
 from sync_tests.utils.db_sync.config import DbSyncConfig
 from sync_tests.utils.db_sync.data import export_epoch_sync_times_from_db
 from sync_tests.utils.db_sync.perf_utils import enrich_perf_stats_with_era
 
 LOGGER = logging.getLogger(__name__)
+
+
+def generate_result_graphs(
+    workdir: pl.Path, results_files: list[pl.Path], mode: str = "auto"
+) -> pl.Path:
+    """Generate performance graphs from sync results JSON files into workdir/graphs.
+
+    Best-effort: a failure here must not fail CI artifact bundling, it only
+    means graphs are skipped for this run (same as if nobody had run
+    sync_static_graphs.py at all).
+
+    Args:
+        workdir: Session working directory; graphs are written to workdir/graphs.
+        results_files: Result JSON files to generate graphs from.
+        mode: "node", "dbsync", or "auto" (majority-vote detection). Pass an
+            explicit mode when results_files is known to be single-purpose,
+            e.g. to generate node graphs even when a db-sync results file is
+            also present in the same workdir.
+
+    Returns:
+        The graphs directory (may be empty if generation failed or produced nothing).
+    """
+    graphs_dir = workdir / "graphs"
+    try:
+        generate_static_graphs(
+            file_list=[str(f) for f in results_files],
+            output_dir=str(graphs_dir),
+            dpi=150,
+            fmt="png",
+            mode=mode,
+        )
+    except Exception:
+        LOGGER.exception("Failed to generate result graphs; continuing without them")
+    return graphs_dir
 
 
 def is_ci_environment() -> bool:


### PR DESCRIPTION
## Summary
- sync_static_graphs.py was documented in README.md as the way to generate performance graphs from sync results, but nothing in CI or any test ever called it; the bundling code only checked for a pre-existing graphs/ directory
- Added artifacts.generate_result_graphs(), a best-effort wrapper around sync_static_graphs.generate_static_graphs() that writes into workdir/graphs and never raises, since a graph failure must not fail artifact bundling
- Wired it into test_prepare_ci_artifacts() in both test_nodesync_artifacts.py and test_dbsync_artifacts.py, right before the existing graphs_dir glob
- Each call site passes an explicit mode ("node" / "dbsync") instead of relying on auto-detection, so a combined node+db-sync run gets both sets of graphs instead of only whichever mode majority-vote auto-detection would pick
- Updated README to describe the new automatic behavior; manual sync_static_graphs.py CLI usage docs are unchanged for local/ad-hoc use

## Test plan
- [x] ruff, mypy, pre-commit all pass on the changed files
- [x] Local fast unit tests still pass
- [x] Verified generate_result_graphs() end to end against a real (stale) db-sync results file in test_workdir/: produced all 7 documented db-sync graphs (dbsync_cpu_over_time.png, dbsync_rss_over_time.png, dbsync_combined_resources.png, dbsync_epoch_duration.png, dbsync_blocks_per_epoch.png, dbsync_block_throughput.png, dbsync_era_breakdown.png)
- [ ] Full local node+db-sync sync test against preview, confirming sync_results.zip actually contains graphs at the end of a real run

Sync test validation in progress, will update this PR with results.