### PR TITLE
Add timeouts and retry to external HTTP calls with no timeout

### DIFF
--- a/sync_tests/tests/test_request_with_retry.py
+++ b/sync_tests/tests/test_request_with_retry.py
@@ -1,0 +1,66 @@
+"""Regression tests for helpers.request_with_retry()."""
+
+from __future__ import annotations
+
+import typing as tp
+
+import pytest
+import requests
+
+from sync_tests.utils import helpers
+
+
+def test_request_with_retry_passes_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every attempt must forward an explicit timeout to requests.request."""
+    captured: dict[str, tp.Any] = {}
+
+    def _fake_request(method: str, url: str, **kwargs: tp.Any) -> str:
+        captured["method"] = method
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return "ok"
+
+    monkeypatch.setattr(requests, "request", _fake_request)
+
+    result = helpers.request_with_retry("get", "https://example.invalid/x")
+
+    assert result == "ok"
+    assert captured["kwargs"]["timeout"] == helpers.DEFAULT_HTTP_TIMEOUT_SECONDS
+
+
+def test_request_with_retry_retries_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient network error must be retried, not raised immediately."""
+    monkeypatch.setattr(helpers.time, "sleep", lambda _seconds: None)
+    attempts: list[int] = []
+
+    def _flaky_request(method: str, url: str, **kwargs: tp.Any) -> str:  # noqa: ARG001
+        attempts.append(1)
+        if len(attempts) < 3:
+            msg = "boom"
+            raise requests.ConnectionError(msg)
+        return "ok"
+
+    monkeypatch.setattr(requests, "request", _flaky_request)
+
+    result = helpers.request_with_retry("get", "https://example.invalid/x", max_attempts=3)
+
+    assert result == "ok"
+    assert len(attempts) == 3
+
+
+def test_request_with_retry_raises_after_exhausting_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once max_attempts is exhausted, the last exception must propagate."""
+    monkeypatch.setattr(helpers.time, "sleep", lambda _seconds: None)
+
+    def _always_fails(method: str, url: str, **kwargs: tp.Any) -> str:  # noqa: ARG001
+        msg = "still boom"
+        raise requests.ConnectionError(msg)
+
+    monkeypatch.setattr(requests, "request", _always_fails)
+
+    with pytest.raises(requests.ConnectionError, match="still boom"):
+        helpers.request_with_retry("get", "https://example.invalid/x", max_attempts=2)

--- a/sync_tests/utils/db_sync/snapshots.py
+++ b/sync_tests/utils/db_sync/snapshots.py
@@ -63,7 +63,9 @@ def get_latest_snapshot_url(env: str, args: tp.Any) -> str:
         raise ValueError(msg)
 
     headers = {"Content-type": "application/json"}
-    res_with_latest_db_sync_version = requests.get(general_snapshot_url, headers=headers)
+    res_with_latest_db_sync_version = helpers.request_with_retry(
+        "get", general_snapshot_url, headers=headers
+    )
     dict_with_latest_db_sync_version = xmltodict.parse(res_with_latest_db_sync_version.content)
     db_sync_latest_version_prefix = dict_with_latest_db_sync_version["ListBucketResult"][
         "CommonPrefixes"
@@ -75,7 +77,9 @@ def get_latest_snapshot_url(env: str, args: tp.Any) -> str:
         msg = "Snapshot are currently available only for mainnet environment"
         raise ValueError(msg)
 
-    res_snapshots_list = requests.get(latest_snapshots_list_url, headers=headers)
+    res_snapshots_list = helpers.request_with_retry(
+        "get", latest_snapshots_list_url, headers=headers
+    )
     dict_snapshots_list = xmltodict.parse(res_snapshots_list.content)
     latest_snapshot = dict_snapshots_list["ListBucketResult"]["Contents"][-2]["Key"]
 
@@ -109,7 +113,8 @@ def download_db_sync_snapshot(snapshot_url: str) -> str:
 def get_snapshot_sha_256_sum(snapshot_url: str) -> str | None:
     """Calculate the SHA-256 checksum of the downloaded snapshot."""
     snapshot_sha_256_sum_url = snapshot_url + ".sha256sum"
-    for line in requests.get(snapshot_sha_256_sum_url):
+    response = helpers.request_with_retry("get", snapshot_sha_256_sum_url)
+    for line in response:
         return line.decode("utf-8").split(" ")[0]
     return None
 

--- a/sync_tests/utils/external/explorer.py
+++ b/sync_tests/utils/external/explorer.py
@@ -8,6 +8,8 @@ import time
 
 import requests
 
+from sync_tests.utils import helpers
+
 LOGGER = logging.getLogger(__name__)
 
 MAINNET_EXPLORER_URL = "https://explorer.cardano.org/graphql"
@@ -74,7 +76,7 @@ def get_epoch_start_datetime_from_explorer(env: str, epoch_no: int) -> str | Non
     try:
         if env in ("preview", "preprod"):
             url = f"{url}{epoch_no}"
-            response = requests.get(url=url, headers=headers)
+            response = helpers.request_with_retry("get", url, headers=headers)
 
             if response.status_code != 200:
                 LOGGER.error("Failed to fetch data from %s: %s", url, response.text)
@@ -86,7 +88,7 @@ def get_epoch_start_datetime_from_explorer(env: str, epoch_no: int) -> str | Non
             else:
                 result = response.json()[0]["start_time"]
         else:
-            response = requests.post(url, data=payload, headers=headers)
+            response = helpers.request_with_retry("post", url, data=payload, headers=headers)
             status_code = response.status_code
 
             if status_code != 200:
@@ -101,7 +103,9 @@ def get_epoch_start_datetime_from_explorer(env: str, epoch_no: int) -> str | Non
                 while "data" in response.json() and response.json().get("data") is None:
                     LOGGER.info("Attempt %s: Response is None. Retrying...", count)
                     time.sleep(30)
-                    response = requests.post(url, data=payload, headers=headers)
+                    response = helpers.request_with_retry(
+                        "post", url, data=payload, headers=headers
+                    )
                     count += 1
 
                     if count > 10:

--- a/sync_tests/utils/helpers.py
+++ b/sync_tests/utils/helpers.py
@@ -14,14 +14,18 @@ import shlex
 import shutil
 import stat
 import subprocess
+import time
 import typing as tp
 import zipfile
 
 import psutil
+import requests
 from colorama import Fore
 from colorama import Style
 
 LOGGER = logging.getLogger(__name__)
+
+DEFAULT_HTTP_TIMEOUT_SECONDS = 30
 
 _NIX_BUILD_LOG_ENV = "SYNC_TESTS_NIX_BUILD_LOG"
 _DEFAULT_NIX_BUILD_LOG = "test_workdir/nix_build.log"
@@ -396,6 +400,57 @@ def get_file_sha256_sum(filepath: str | pl.Path) -> str:
     """
     with open(filepath, "rb") as f:
         return hashlib.file_digest(f, hashlib.sha256).hexdigest()
+
+
+def request_with_retry(
+    method: str,
+    url: str,
+    max_attempts: int = 3,
+    timeout: float = DEFAULT_HTTP_TIMEOUT_SECONDS,
+    **kwargs: tp.Any,
+) -> requests.Response:
+    """Issue an HTTP request with a timeout and exponential-backoff retry.
+
+    A hung remote endpoint must fail fast and retry rather than block a
+    multi-hour sync-test job indefinitely.
+
+    Args:
+        method: HTTP method, e.g. "get" or "post".
+        url: Request URL.
+        max_attempts: Number of attempts before giving up.
+        timeout: Per-request timeout in seconds.
+        **kwargs: Forwarded to ``requests.request`` (headers, data, stream, ...).
+
+    Returns:
+        The ``requests.Response`` from the first successful attempt.
+
+    Raises:
+        requests.RequestException: If every attempt fails (connection error or timeout).
+    """
+    last_exc: requests.RequestException | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return requests.request(method, url, timeout=timeout, **kwargs)
+        except requests.RequestException as exc:
+            last_exc = exc
+            if attempt == max_attempts:
+                break
+            backoff_secs = 2 ** (attempt - 1)
+            LOGGER.warning(
+                "%s %s failed on attempt %s/%s: %s. Retrying in %ss.",
+                method.upper(),
+                url,
+                attempt,
+                max_attempts,
+                exc,
+                backoff_secs,
+            )
+            time.sleep(backoff_secs)
+
+    if last_exc is None:  # unreachable, satisfies type checking
+        msg = "request_with_retry exhausted attempts without an exception"
+        raise RuntimeError(msg)
+    raise last_exc
 
 
 def print_last_n_lines(file_path: str | pl.Path, n: int) -> None:


### PR DESCRIPTION
## Summary
- sync_tests/utils/external/explorer.py (3 calls) and sync_tests/utils/db_sync/snapshots.py (3 calls) issued requests.get/post with no timeout: a hung remote endpoint could block a multi-hour sync-test job indefinitely with no way to recover
- The snapshot download calls in snapshots.py (lines 40, 102) already had timeouts and are unchanged
- Added helpers.request_with_retry(), a thin wrapper around requests.request with an explicit per-request timeout (default 30s) and exponential-backoff retry on requests.RequestException, mirroring the retry pattern conftest.py already uses for CONFIGS_BASE_URL validation
- Routed every previously-timeout-less call through it; explorer.py's own business-logic retry loop (for GraphQL responses with data=None) is unchanged, since that's a different concern from transport-level timeout/retry

## Test plan
- [x] ruff, mypy, pre-commit all pass on the changed files
- [x] New unit tests (test_request_with_retry.py) cover: timeout always forwarded, transient failure retried then succeeds, last exception propagates once attempts exhausted
- [x] Local fast unit tests still pass
- [ ] Full local node+db-sync sync test against preview to confirm the retry wrapper doesn't change happy-path behavior

Sync test validation in progress, will update this PR with results.