### PR TITLE
Collapse duplicated node bring-up in restoration tests into run_node_sync

### DIFF
--- a/sync_tests/tests/test_iohk_snapshot_restoration.py
+++ b/sync_tests/tests/test_iohk_snapshot_restoration.py
@@ -16,7 +16,7 @@ from _pytest.fixtures import FixtureRequest
 from sync_tests.tests.conftest import SyncContext
 from sync_tests.utils import db_sync
 from sync_tests.utils import helpers
-from sync_tests.utils import node
+from sync_tests.utils import sync_entries
 from sync_tests.utils.external import gitpython
 from sync_tests.utils.logs import log_analyzer
 
@@ -70,43 +70,24 @@ def iohk_restoration_result(
     snapshot_url = snapshot_url_opt or db_sync.get_latest_snapshot_url(env, None)
     LOGGER.info("Snapshot URL: %s", snapshot_url)
 
-    # node setup
-    conf_dir = pl.Path.cwd()
+    # node setup (reuses conftest's run_node_sync instead of hand-rolling the same
+    # build+start+wait-for-sync sequence a third time; clean_start=False preserves
+    # this test's original behavior of reusing an already-synced node db if one is
+    # already present from an earlier step in the same session)
     base_dir = pl.Path.cwd()
-    bin_dir = pl.Path("bin")
-    bin_dir.mkdir(exist_ok=True)
-    node.add_to_path(path=bin_dir)
-
-    node.set_node_socket_path_env_var(base_dir=base_dir)
-    node.get_node_files(node_rev=node_revision, base_dir=base_dir)
-    cli_version, cli_git_rev = node.get_node_version()
-    node.rm_node_config_files(conf_dir=conf_dir)
-    node.get_node_config_files(
+    node_run_result = sync_entries.run_node_sync(
         env=env,
-        node_topology_type="",
-        conf_dir=conf_dir,
-        disable_genesis_mode_flag=False,
-    )
-    node.configure_node(config_file=conf_dir / "config.json")
-    node.start_node(
+        node_revision=node_revision,
+        node_logfile_path=config.node_log_file,
         base_dir=base_dir,
-        node_start_arguments=(),
-        logfile_path=config.node_log_file,
+        conf_dir=base_dir,
+        start_era="shelley",
+        clean_start=False,
+        full_sync=True,
     )
-    node.wait_node_start(
-        env=env,
-        base_dir=base_dir,
-        timeout_minutes=10,
-        logfile_path=config.node_log_file,
-    )
-    helpers.print_last_n_lines(config.node_log_file, 80)
-    (
-        node_sync_time_seconds,
-        _last_slot_no,
-        _latest_chunk_no,
-        _era_details_dict,
-        _epoch_details_dict,
-    ) = node.wait_for_node_to_sync(env=env, base_dir=base_dir)
+    cli_version = node_run_result.cli_version
+    cli_git_rev = node_run_result.cli_git_rev
+    node_sync_time_seconds = node_run_result.sync_time_sec
 
     # db-sync setup
     LOGGER.info("Building db-sync from revision: %s", db_sync_revision)
@@ -210,17 +191,7 @@ def iohk_restoration_result(
     yield result
 
     LOGGER.info("Teardown: terminating cardano services")
-    helpers.manage_process(
-        proc_name="cardano-db-sync",
-        action="terminate",
-    )
-    helpers.manage_process(
-        proc_name="cardano-node",
-        action="terminate",
-    )
-    node.rm_node_db_dir(base_dir=base_dir)
-    db_sync.stop_postgres(config)
-    db_sync.finalize_session_disk_cleanup(config)
+    sync_entries.teardown_node_and_db_sync(base_dir=base_dir, config=config)
 
 
 class TestIohkSnapshotRestoration:

--- a/sync_tests/tests/test_local_snapshot_restoration.py
+++ b/sync_tests/tests/test_local_snapshot_restoration.py
@@ -17,7 +17,7 @@ from _pytest.fixtures import FixtureRequest
 from sync_tests.tests.conftest import SyncContext
 from sync_tests.utils import db_sync
 from sync_tests.utils import helpers
-from sync_tests.utils import node
+from sync_tests.utils import sync_entries
 from sync_tests.utils.logs import log_analyzer
 
 LOGGER = logging.getLogger(__name__)
@@ -111,38 +111,22 @@ def local_restoration_result(
         snapshot_slot_no,
     )
 
-    # start node
+    # start node (reuses conftest's run_node_sync instead of hand-rolling the same
+    # build+start+wait-for-sync sequence a third time; clean_start=False preserves
+    # this test's original behavior of reusing an already-synced node db if one is
+    # already present from an earlier step in the same session)
     LOGGER.info("Starting node for post-restoration sync")
-    conf_dir = pl.Path.cwd()
     base_dir = pl.Path.cwd()
-    bin_dir = pl.Path("bin")
-    bin_dir.mkdir(exist_ok=True)
-    node.add_to_path(path=bin_dir)
-
-    node.set_node_socket_path_env_var(base_dir=base_dir)
-    node.get_node_files(node_rev=node_revision, base_dir=base_dir)
-    _cli_version, _cli_git_rev = node.get_node_version()
-    node.rm_node_config_files(conf_dir=conf_dir)
-    node.get_node_config_files(
+    sync_entries.run_node_sync(
         env=env,
-        node_topology_type="",
-        conf_dir=conf_dir,
-        disable_genesis_mode_flag=False,
-    )
-    node.configure_node(config_file=conf_dir / "config.json")
-    node.start_node(
+        node_revision=node_revision,
+        node_logfile_path=config.node_log_file,
         base_dir=base_dir,
-        node_start_arguments=(),
-        logfile_path=config.node_log_file,
+        conf_dir=base_dir,
+        start_era="shelley",
+        clean_start=False,
+        full_sync=True,
     )
-    node.wait_node_start(
-        env=env,
-        base_dir=base_dir,
-        timeout_minutes=10,
-        logfile_path=config.node_log_file,
-    )
-    helpers.print_last_n_lines(config.node_log_file, 80)
-    node.wait_for_node_to_sync(env=env, base_dir=base_dir)
 
     # start db-sync
     LOGGER.info("Starting db-sync after snapshot restoration")
@@ -194,17 +178,7 @@ def local_restoration_result(
     yield result
 
     LOGGER.info("Teardown: terminating cardano services")
-    helpers.manage_process(
-        proc_name="cardano-db-sync",
-        action="terminate",
-    )
-    helpers.manage_process(
-        proc_name="cardano-node",
-        action="terminate",
-    )
-    node.rm_node_db_dir(base_dir=base_dir)
-    db_sync.stop_postgres(config)
-    db_sync.finalize_session_disk_cleanup(config)
+    sync_entries.teardown_node_and_db_sync(base_dir=base_dir, config=config)
 
 
 class TestLocalSnapshotRestoration:

--- a/sync_tests/utils/sync_entries.py
+++ b/sync_tests/utils/sync_entries.py
@@ -277,3 +277,20 @@ def run_db_sync(
         perf_stats=perf_stats,
         db_sync_tip=db_sync_tip,
     )
+
+
+def teardown_node_and_db_sync(base_dir: pl.Path, config: db_sync.DbSyncConfig) -> None:
+    """Terminate node/db-sync processes and clean up after a session.
+
+    Shared by the snapshot-restoration test fixtures so the same teardown
+    sequence isn't hand-rolled in each one.
+
+    Args:
+        base_dir: Root directory the node was started in (for DB dir removal).
+        config: Db-sync configuration used to stop postgres and finalize cleanup.
+    """
+    helpers.manage_process(proc_name="cardano-db-sync", action="terminate")
+    helpers.manage_process(proc_name="cardano-node", action="terminate")
+    node.rm_node_db_dir(base_dir=base_dir)
+    db_sync.stop_postgres(config)
+    db_sync.finalize_session_disk_cleanup(config)


### PR DESCRIPTION
## Summary
Node build+start+wait-for-sync was implemented three times: once in `sync_entries.run_node_sync()` (used by conftest's `node_synced` fixture, the primary sync test path), and independently, nearly line-for-line, in `test_local_snapshot_restoration.py` and `test_iohk_snapshot_restoration.py`. A fix to node startup (like the space-in-path fix in `start_node()`, see #148) had to be made in all three places or it would silently only apply to one.

- Both restoration tests now call `sync_entries.run_node_sync(..., clean_start=False, full_sync=True)` instead of hand-rolling the same sequence
- `clean_start=False` preserves each test's original behavior of reusing an already-synced node db if one is already present from an earlier step in the same session (neither test ever wiped `base_dir/db` before starting)
- This also fixes two latent bugs the hand-rolled versions had that `run_node_sync` doesn't: `cli_version` was never passed to `configure_node()` (so the pre-10.5 peer-snapshot downgrade never applied), and `node_topology_type` was hardcoded to `""` even for mainnet (missing the `non-bootstrap-peers` topology `run_node_sync` already selects for mainnet)
- Extracted the identical 5-line teardown sequence (terminate db-sync/node, remove node db dir, stop postgres, finalize disk cleanup) duplicated in both restoration test fixtures into `sync_entries.teardown_node_and_db_sync()`
- `conftest.py`'s `node_synced`/`db_sync_synced` fixtures and `run_node_sync()`/`run_db_sync()` themselves are unchanged; only the two restoration test fixtures now call the existing function instead of reimplementing it

## Test plan
- [x] ruff, mypy (44 source files), and pre-commit all pass
- [x] `pytest --collect-only` still collects all 33 tests with no import errors
- [x] Local fast unit tests still pass
- [ ] Full local node+db-sync sync test against preview (in progress in #147, exercises the unchanged `run_node_sync`/`run_db_sync` that this PR now also routes restoration tests through)
- [ ] Local snapshot restoration test end-to-end, once the shared validation db-sync sync completes

Sync test validation in progress, will update this PR with results.