### PR TITLE
Write test results to the GitHub Actions job summary

### DIFF
--- a/.github/workflows/db_sync_full_sync.yaml
+++ b/.github/workflows/db_sync_full_sync.yaml
@@ -112,7 +112,7 @@ jobs:
             nix develop -v --accept-flake-config .#python --command pytest "${pytest_args[@]}"
           } > test_workdir/ci_step.log 2>&1 || pytest_exit=$?
 
-          bash sync_tests/scripts/print-ci-summary.sh test_workdir/ci_step.log
+          bash sync_tests/scripts/print-ci-summary.sh test_workdir/ci_step.log "$pytest_exit"
           exit "$pytest_exit"
 
       - name: Recent log tails on failure

--- a/.github/workflows/node_sync_test.yaml
+++ b/.github/workflows/node_sync_test.yaml
@@ -86,7 +86,7 @@ jobs:
               --node-revision "${{ steps.rev.outputs.node_revision }}"
           } > test_workdir/ci_step.log 2>&1 || pytest_exit=$?
 
-          bash sync_tests/scripts/print-ci-summary.sh test_workdir/ci_step.log
+          bash sync_tests/scripts/print-ci-summary.sh test_workdir/ci_step.log "$pytest_exit"
           exit "$pytest_exit"
 
       - name: Recent log tails on failure

--- a/sync_tests/scripts/print-ci-summary.sh
+++ b/sync_tests/scripts/print-ci-summary.sh
@@ -1,17 +1,28 @@
 #! /usr/bin/env bash
 # shellcheck shell=bash
-# print-ci-summary.sh [CI_STEP_LOG]
+# print-ci-summary.sh [CI_STEP_LOG] [EXIT_CODE]
 #
 # Print pytest PASSED/SKIPPED/FAILED lines and final summary from ci_step.log.
+# When running in GitHub Actions (GITHUB_STEP_SUMMARY set), also write the
+# same summary to the job's Summary tab so results are visible at a glance,
+# without opening the raw log and expanding the folded group.
 
 set -uo pipefail
 
 LOG="${1:-test_workdir/ci_step.log}"
+EXIT_CODE="${2:-}"
 
-echo "::group::Test summary"
 if [ ! -f "$LOG" ]; then
+  echo "::group::Test summary"
   echo "[ci_step.log not found]"
   echo "::endgroup::"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+      echo "## Sync test summary"
+      echo ""
+      echo "ci_step.log not found."
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
   exit 0
 fi
 
@@ -22,13 +33,14 @@ printed="$(
     /::.* (PASSED|SKIPPED|FAILED) \[/ { started=1 }
     /^=+ short test summary info =+/ { started=1 }
     started { print; found=1 }
-    /^=+[[:space:]]+[0-9]+ passed/ { print; exit }
-    /^=+[[:space:]]+[0-9]+ failed/ { print; exit }
-    /^=+.* (passed|failed|error).* in [0-9]/ { if (started) print; exit }
+    /^=+[[:space:]]+[0-9]+ passed/ { if (!started) print; exit }
+    /^=+[[:space:]]+[0-9]+ failed/ { if (!started) print; exit }
+    /^=+.* (passed|failed|error).* in [0-9]/ { if (!started) print; exit }
     END { if (!found) exit 1 }
   ' "$LOG" 2>/dev/null || true
 )"
 
+echo "::group::Test summary"
 if [ -n "$printed" ]; then
   printf '%s\n' "$printed"
 else
@@ -36,3 +48,26 @@ else
   tail -n 80 "$LOG"
 fi
 echo "::endgroup::"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  status_line="Result: status unknown"
+  if [ "$EXIT_CODE" = "0" ]; then
+    status_line="Result: :white_check_mark: passed"
+  elif [ -n "$EXIT_CODE" ]; then
+    status_line="Result: :x: failed (exit $EXIT_CODE)"
+  fi
+
+  {
+    echo "## Sync test summary"
+    echo ""
+    echo "$status_line"
+    echo ""
+    echo '```'
+    if [ -n "$printed" ]; then
+      printf '%s\n' "$printed"
+    else
+      echo "pytest summary not found; see the job log for details."
+    fi
+    echo '```'
+  } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/sync_tests/scripts/print-ci-summary.sh
+++ b/sync_tests/scripts/print-ci-summary.sh
@@ -21,7 +21,7 @@ if [ ! -f "$LOG" ]; then
       echo "## Sync test summary"
       echo ""
       echo "ci_step.log not found."
-    } >> "$GITHUB_STEP_SUMMARY"
+    } >> "$GITHUB_STEP_SUMMARY" || true
   fi
   exit 0
 fi
@@ -69,5 +69,11 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
       echo "pytest summary not found; see the job log for details."
     fi
     echo '```'
-  } >> "$GITHUB_STEP_SUMMARY"
+  } >> "$GITHUB_STEP_SUMMARY" || true
 fi
+
+# This script is purely informational (console log + job summary); a glitch
+# writing either one must never fail the calling CI step, which runs under
+# set -euo pipefail and would otherwise abort before it reports pytest's own
+# exit code.
+exit 0


### PR DESCRIPTION
## Summary
- print-ci-summary.sh only echoed its pass/fail summary into a folded ::group:: inside the raw job log, so checking results meant opening the job log and expanding that group
- Nothing wrote to GITHUB_STEP_SUMMARY, the file GitHub Actions renders as the prominent Summary tab on a workflow run page, visible without opening any logs
- node_sync_test.yaml and db_sync_full_sync.yaml now pass the pytest exit code to print-ci-summary.sh, which appends a markdown summary (pass/fail status plus the pytest summary lines) to GITHUB_STEP_SUMMARY when running in CI
- Local runs are unaffected since GITHUB_STEP_SUMMARY is unset outside GitHub Actions
- Also fixed a pre-existing quirk where the final "N passed"/"N failed" line printed twice when individual PASSED/FAILED lines were already shown; now prints exactly once in all cases (pass, fail, and collection-error-with-zero-individual-lines)

## Test plan
- [x] shellcheck, yaml validation, pre-commit all pass
- [x] Manually verified the script end to end in three modes: local (no GITHUB_STEP_SUMMARY, unchanged group-only output), simulated CI pass, simulated CI fail, plus the zero-individual-lines collection-error edge case
- [x] Confirmed the duplicate final-summary-line fix across all of the above