### PR TITLE
Retry timeout on config downloads

### DIFF
--- a/sync_tests/tests/test_config_downloads.py
+++ b/sync_tests/tests/test_config_downloads.py
@@ -1,0 +1,99 @@
+"""Regression tests for node config download error handling."""
+
+from __future__ import annotations
+
+import pathlib as pl
+import typing as tp
+
+import pytest
+import requests
+
+from sync_tests.utils import node
+
+
+def _http_error(status_code: int) -> requests.HTTPError:
+    response = requests.Response()
+    response.status_code = status_code
+    return requests.HTTPError(response=response)
+
+
+def test_download_config_file_closes_response(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pl.Path
+) -> None:
+    """The streamed response must be closed, not leaked, after downloading."""
+    closed = {"value": False}
+
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            pass
+
+        def iter_content(self, chunk_size: int) -> tp.Iterator[bytes]:  # noqa: ARG002
+            yield b"content"
+
+        def __enter__(self) -> _FakeResponse:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            closed["value"] = True
+
+    monkeypatch.setattr(node.helpers, "request_with_retry", lambda *_a, **_kw: _FakeResponse())
+
+    node.download_config_file("preview/config.json", tmp_path / "config.json")
+
+    assert closed["value"] is True
+
+
+def test_checkpoints_404_is_swallowed(monkeypatch: pytest.MonkeyPatch, tmp_path: pl.Path) -> None:
+    """A 404 for checkpoints.json means it genuinely doesn't exist; safe to skip."""
+
+    def _fake_download(config_slug: str, save_as: pl.Path) -> None:
+        if "checkpoints.json" in config_slug:
+            raise _http_error(404)
+        save_as.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(node, "download_config_file", _fake_download)
+
+    # Should not raise.
+    node.get_node_config_files(env="preview", node_topology_type="", conf_dir=tmp_path)
+
+
+def test_checkpoints_server_error_is_not_swallowed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pl.Path
+) -> None:
+    """A 500 is a real failure and must propagate, not be treated as "not published"."""
+
+    def _fake_download(config_slug: str, save_as: pl.Path) -> None:
+        if "checkpoints.json" in config_slug:
+            raise _http_error(500)
+        save_as.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(node, "download_config_file", _fake_download)
+
+    with pytest.raises(requests.HTTPError):
+        node.get_node_config_files(env="preview", node_topology_type="", conf_dir=tmp_path)
+
+
+def test_peer_snapshot_404_is_swallowed(monkeypatch: pytest.MonkeyPatch, tmp_path: pl.Path) -> None:
+    def _fake_download(config_slug: str, save_as: pl.Path) -> None:
+        if "peer-snapshot.json" in config_slug:
+            raise _http_error(404)
+        save_as.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(node, "download_config_file", _fake_download)
+
+    # Should not raise.
+    node.get_node_config_files(env="preview", node_topology_type="", conf_dir=tmp_path)
+
+
+def test_peer_snapshot_server_error_is_not_swallowed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pl.Path
+) -> None:
+    def _fake_download(config_slug: str, save_as: pl.Path) -> None:
+        if "peer-snapshot.json" in config_slug:
+            raise _http_error(503)
+        save_as.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(node, "download_config_file", _fake_download)
+
+    with pytest.raises(requests.HTTPError):
+        node.get_node_config_files(env="preview", node_topology_type="", conf_dir=tmp_path)

--- a/sync_tests/utils/node/__init__.py
+++ b/sync_tests/utils/node/__init__.py
@@ -14,9 +14,9 @@ import socket
 import subprocess
 import time
 import typing as tp
-import urllib.request
 
 import git
+import requests
 
 from sync_tests.utils import exceptions
 from sync_tests.utils import helpers
@@ -99,9 +99,24 @@ def normalize_peer_snapshot(file_path: pl.Path) -> None:
 
 
 def download_config_file(config_slug: str, save_as: pl.Path) -> None:
+    """Download a single environment config file, with a timeout and retries.
+
+    Args:
+        config_slug: Path segment appended to CONFIGS_BASE_URL, e.g. "preview/config.json".
+        save_as: Local path to write the downloaded file to.
+
+    Raises:
+        requests.HTTPError: The server responded, but with an error status (e.g. 404
+            because this file genuinely isn't published for this environment).
+        requests.RequestException: The request failed at the transport level (timeout,
+            connection error) even after retries.
+    """
     url = f"{CONFIGS_BASE_URL}/{config_slug}"
     LOGGER.info("Downloading '%s' and saving as '%s'", url, save_as)
-    urllib.request.urlretrieve(url, save_as)
+    response = helpers.request_with_retry("get", url, stream=True)
+    response.raise_for_status()
+    with open(save_as, "wb") as f:
+        f.writelines(response.iter_content(chunk_size=8192))
 
 
 def get_node_config_files(
@@ -153,7 +168,8 @@ def get_node_config_files(
         LOGGER.info("Downloaded peer snapshot for %s", env)
         # Normalize format: IOG uses 'domain', node expects 'address'
         normalize_peer_snapshot(peer_snapshot_path)
-    except Exception:
+    except requests.HTTPError:
+        # Genuinely not published for this environment; safe to skip.
         LOGGER.warning("peer-snapshot.json not available for %s", env)
 
     # Genesis mode is the default (configs from IOG have it enabled)
@@ -166,8 +182,11 @@ def get_node_config_files(
         download_config_file(
             config_slug=f"{env}/checkpoints.json", save_as=conf_dir / "checkpoints.json"
         )
-    except Exception:
-        LOGGER.warning("checkpoints.json file not available")
+    except requests.HTTPError:
+        # Genuinely not published for this environment; safe to skip. A network
+        # failure after retries is not caught here, it must fail loudly instead
+        # of silently starting a node whose config still points at a missing file.
+        LOGGER.warning("checkpoints.json file not available for %s", env)
 
 
 def delete_node_files(node_dir: pl.Path) -> None:

--- a/sync_tests/utils/node/__init__.py
+++ b/sync_tests/utils/node/__init__.py
@@ -113,10 +113,10 @@ def download_config_file(config_slug: str, save_as: pl.Path) -> None:
     """
     url = f"{CONFIGS_BASE_URL}/{config_slug}"
     LOGGER.info("Downloading '%s' and saving as '%s'", url, save_as)
-    response = helpers.request_with_retry("get", url, stream=True)
-    response.raise_for_status()
-    with open(save_as, "wb") as f:
-        f.writelines(response.iter_content(chunk_size=8192))
+    with helpers.request_with_retry("get", url, stream=True) as response:
+        response.raise_for_status()
+        with open(save_as, "wb") as f:
+            f.writelines(response.iter_content(chunk_size=8192))
 
 
 def get_node_config_files(
@@ -168,9 +168,14 @@ def get_node_config_files(
         LOGGER.info("Downloaded peer snapshot for %s", env)
         # Normalize format: IOG uses 'domain', node expects 'address'
         normalize_peer_snapshot(peer_snapshot_path)
-    except requests.HTTPError:
-        # Genuinely not published for this environment; safe to skip.
-        LOGGER.warning("peer-snapshot.json not available for %s", env)
+    except requests.HTTPError as exc:
+        # Only a 404 means genuinely not published for this environment; any
+        # other status (500, 503, ...) is a real failure and must not be
+        # treated the same as "safe to skip".
+        if exc.response is not None and exc.response.status_code == 404:
+            LOGGER.warning("peer-snapshot.json not available for %s", env)
+        else:
+            raise
 
     # Genesis mode is the default (configs from IOG have it enabled)
     # Only disable if explicitly requested
@@ -182,11 +187,15 @@ def get_node_config_files(
         download_config_file(
             config_slug=f"{env}/checkpoints.json", save_as=conf_dir / "checkpoints.json"
         )
-    except requests.HTTPError:
-        # Genuinely not published for this environment; safe to skip. A network
-        # failure after retries is not caught here, it must fail loudly instead
-        # of silently starting a node whose config still points at a missing file.
-        LOGGER.warning("checkpoints.json file not available for %s", env)
+    except requests.HTTPError as exc:
+        # Only a 404 means genuinely not published for this environment. Any
+        # other status (500, 503, ...), or a network failure after retries,
+        # must fail loudly instead of silently starting a node whose config
+        # still points at a checkpoints file that was never written.
+        if exc.response is not None and exc.response.status_code == 404:
+            LOGGER.warning("checkpoints.json file not available for %s", env)
+        else:
+            raise
 
 
 def delete_node_files(node_dir: pl.Path) -> None:


### PR DESCRIPTION
## Summary
Depends on #156 (uses helpers.request_with_retry() added there), based on that branch instead of main.

- download_config_file() used urllib.request.urlretrieve with no timeout
- get_node_config_files() silently swallowed any exception from the checkpoints.json and peer-snapshot.json downloads with just a warning log
- This is exactly what caused a node_sync_test.yaml failure: checkpoints.json failed to download (a transient network issue), the failure was silently swallowed, and cardano-node crashed on startup because its config still referenced a checkpoints file that was never written
- download_config_file() now uses helpers.request_with_retry(), so a flaky connection gets retried with a timeout instead of failing on the first hiccup
- The two call sites now only swallow requests.HTTPError (server said the file genuinely does not exist for this environment); a requests.RequestException from retries being exhausted now propagates instead of being logged as a warning

## Test plan
- [x] ruff, mypy (41 source files), and the local unit test suite pass
- [x] Verified against the real config server: a normal download still works, a 404 still raises HTTPError as before
- [x] Verified preview/checkpoints.json downloads successfully today, confirming the original CI failure was transient