### PR TITLE
fix: testnet snapshot creation and restoration

### DIFF
--- a/sync_tests/scripts/postgres-start.sh
+++ b/sync_tests/scripts/postgres-start.sh
@@ -23,11 +23,22 @@ export PGUSER="${PGUSER:-postgres}"
 
 # kill running postgres and clear its data
 if [ "${2:-""}" = "-k" ]; then
-  # try to kill whatever is listening on postgres port
-  listening_pid="$(lsof -i:"$PGPORT" -t || echo "")"
-  if [ -n "$listening_pid" ]; then
-    if ! kill "$listening_pid"; then
-      echo "Warning: failed to kill PID $listening_pid on port $PGPORT." >&2
+  # lsof -t lists one PID per backend connection, not just the postmaster,
+  # so there can be several lines to kill, not just one.
+  listening_pids="$(lsof -i:"$PGPORT" -t || true)"
+  if [ -n "$listening_pids" ]; then
+    while IFS= read -r pid; do
+      [ -n "$pid" ] || continue
+      kill "$pid" 2>/dev/null || echo "Warning: failed to kill PID $pid on port $PGPORT." >&2
+    done <<< "$listening_pids"
+
+    # wait for postgres to actually release the data dir before wiping it
+    for _ in $(seq 1 30); do
+      [ -z "$(lsof -i:"$PGPORT" -t || true)" ] && break
+      sleep 1
+    done
+    if [ -n "$(lsof -i:"$PGPORT" -t || true)" ]; then
+      echo "Warning: postgres on port $PGPORT did not stop in time." >&2
       echo "Another postgres may be running. Stop it or set PGPORT to a free port." >&2
     fi
   fi

--- a/sync_tests/tests/conftest.py
+++ b/sync_tests/tests/conftest.py
@@ -522,3 +522,53 @@ def db_sync_synced(
     db_sync.stop_monitor(sync_context.workdir)
     db_sync.stop_postgres(config)
     db_sync.finalize_session_disk_cleanup(config)
+
+
+@pytest.fixture(scope="session")
+def snapshot_created(
+    request: FixtureRequest,
+    sync_context: SyncContext,
+    db_sync_synced: DbSyncResult,  # noqa: ARG001
+) -> dict[str, tp.Any]:
+    """Create a db-sync snapshot and return creation metadata.
+
+    Defined here rather than in a test module so it stays a single shared
+    fixture instance regardless of which test file requests it first;
+    pytest does not share a cached fixture across modules that each import
+    it directly.
+    """
+    if request.config.getoption("--run-only-sync-test"):
+        pytest.skip("--run-only-sync-test: skipping snapshot creation")
+
+    env = sync_context.env
+    config = db_sync.create_db_sync_config(
+        env=env,
+        workdir=sync_context.workdir,
+    )
+
+    LOGGER.info("Starting snapshot creation")
+    start_time = datetime.datetime.now(tz=datetime.timezone.utc)
+    stage_2_cmd = db_sync.create_db_sync_snapshot_stage_1(config)
+    LOGGER.info("Stage 2 command: %s", stage_2_cmd)
+    stage_2_result = db_sync.create_db_sync_snapshot_stage_2(
+        config,
+        stage_2_cmd,
+    )
+    LOGGER.info("Stage 2 result: %s", stage_2_result)
+    end_time = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    snapshot_file = stage_2_result
+
+    creation_secs = int((end_time - start_time).total_seconds())
+    LOGGER.info("Snapshot creation time: %d seconds", creation_secs)
+
+    snapshot_data = {
+        "snapshot_file": snapshot_file,
+        "stage_2_cmd": stage_2_cmd,
+        "stage_2_result": stage_2_result,
+        "creation_time_secs": creation_secs,
+        "start_time": start_time.strftime("%d/%m/%Y %H:%M:%S"),
+        "end_time": end_time.strftime("%d/%m/%Y %H:%M:%S"),
+    }
+    helpers.write_json_to_file(sync_context.workdir / "sync_session_state.json", snapshot_data)
+    return snapshot_data

--- a/sync_tests/tests/test_local_snapshot_restoration.py
+++ b/sync_tests/tests/test_local_snapshot_restoration.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import datetime
-import json
 import logging
 import os
 import pathlib as pl
@@ -15,6 +14,7 @@ import pytest
 from _pytest.fixtures import FixtureRequest
 
 from sync_tests.tests.conftest import SyncContext
+from sync_tests.tests.test_snapshot_creation import snapshot_created  # noqa: F401
 from sync_tests.utils import db_sync
 from sync_tests.utils import helpers
 from sync_tests.utils import sync_entries
@@ -31,15 +31,17 @@ POST_SYNC_WAIT_MINUTES = 20
 def local_restoration_result(
     request: FixtureRequest,
     sync_context: SyncContext,
+    snapshot_created: dict[str, tp.Any],  # noqa: F811
 ) -> tp.Generator[dict[str, tp.Any], None, None]:
     """Restore db-sync from a local snapshot, sync, and yield result data.
 
-    Reads snapshot metadata written by a prior snapshot creation run. Run the
-    snapshot_creation marked tests first to produce that metadata.
+    Depends on the snapshot_created fixture directly so pytest always runs
+    snapshot creation first, regardless of test file collection order.
 
     Args:
         request: Pytest fixture request for CLI options.
         sync_context: Shared session context.
+        snapshot_created: Snapshot metadata from the snapshot_creation fixture.
 
     Yields:
         Dict with restoration timing, tip data, and sync results.
@@ -79,17 +81,7 @@ def local_restoration_result(
     db_sync.create_database()
 
     # restore snapshot
-    snapshot_state_file = sync_context.workdir / "sync_session_state.json"
-    if not snapshot_state_file.exists():
-        msg = f"Snapshot metadata file not found: {snapshot_state_file}"
-        raise FileNotFoundError(msg)
-    try:
-        with open(snapshot_state_file, encoding="utf-8") as state_fh:
-            snapshot_data = json.load(state_fh)
-        snapshot_file = snapshot_data["snapshot_file"]
-    except (json.JSONDecodeError, KeyError) as exc:
-        msg = f"Invalid snapshot metadata in {snapshot_state_file}: {exc}"
-        raise ValueError(msg) from exc
+    snapshot_file = snapshot_created["snapshot_file"]
     LOGGER.info("Restoring from snapshot: %s", snapshot_file)
     restoration_time = db_sync.restore_db_sync_from_snapshot(
         config,

--- a/sync_tests/tests/test_local_snapshot_restoration.py
+++ b/sync_tests/tests/test_local_snapshot_restoration.py
@@ -14,7 +14,6 @@ import pytest
 from _pytest.fixtures import FixtureRequest
 
 from sync_tests.tests.conftest import SyncContext
-from sync_tests.tests.test_snapshot_creation import snapshot_created  # noqa: F401
 from sync_tests.utils import db_sync
 from sync_tests.utils import helpers
 from sync_tests.utils import sync_entries
@@ -31,7 +30,7 @@ POST_SYNC_WAIT_MINUTES = 20
 def local_restoration_result(
     request: FixtureRequest,
     sync_context: SyncContext,
-    snapshot_created: dict[str, tp.Any],  # noqa: F811
+    snapshot_created: dict[str, tp.Any],
 ) -> tp.Generator[dict[str, tp.Any], None, None]:
     """Restore db-sync from a local snapshot, sync, and yield result data.
 

--- a/sync_tests/tests/test_local_snapshot_restoration.py
+++ b/sync_tests/tests/test_local_snapshot_restoration.py
@@ -66,6 +66,7 @@ def local_restoration_result(
         env=env,
         workdir=sync_context.workdir,
         pg_port=pg_port,
+        perf_stats_filename="db_sync_performance_stats_restoration.json",
     )
 
     platform_system, platform_release, platform_version = helpers.get_os_type()

--- a/sync_tests/tests/test_snapshot_creation.py
+++ b/sync_tests/tests/test_snapshot_creation.py
@@ -9,7 +9,6 @@ import typing as tp
 from collections import OrderedDict
 
 import pytest
-from _pytest.fixtures import FixtureRequest
 
 from sync_tests.tests.conftest import DbSyncResult
 from sync_tests.tests.conftest import SyncContext
@@ -19,50 +18,6 @@ from sync_tests.utils import helpers
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.snapshot_creation
-
-
-@pytest.fixture(scope="session")
-def snapshot_created(
-    request: FixtureRequest,
-    sync_context: SyncContext,
-    db_sync_synced: DbSyncResult,  # noqa: ARG001
-) -> dict[str, tp.Any]:
-    """Create a db-sync snapshot and return creation metadata."""
-    if request.config.getoption("--run-only-sync-test"):
-        pytest.skip("--run-only-sync-test: skipping snapshot creation")
-
-    env = sync_context.env
-    config = db_sync.create_db_sync_config(
-        env=env,
-        workdir=sync_context.workdir,
-    )
-
-    LOGGER.info("Starting snapshot creation")
-    start_time = datetime.datetime.now(tz=datetime.timezone.utc)
-    stage_2_cmd = db_sync.create_db_sync_snapshot_stage_1(config)
-    LOGGER.info("Stage 2 command: %s", stage_2_cmd)
-    stage_2_result = db_sync.create_db_sync_snapshot_stage_2(
-        config,
-        stage_2_cmd,
-    )
-    LOGGER.info("Stage 2 result: %s", stage_2_result)
-    end_time = datetime.datetime.now(tz=datetime.timezone.utc)
-
-    snapshot_file = stage_2_result
-
-    creation_secs = int((end_time - start_time).total_seconds())
-    LOGGER.info("Snapshot creation time: %d seconds", creation_secs)
-
-    snapshot_data = {
-        "snapshot_file": snapshot_file,
-        "stage_2_cmd": stage_2_cmd,
-        "stage_2_result": stage_2_result,
-        "creation_time_secs": creation_secs,
-        "start_time": start_time.strftime("%d/%m/%Y %H:%M:%S"),
-        "end_time": end_time.strftime("%d/%m/%Y %H:%M:%S"),
-    }
-    helpers.write_json_to_file(sync_context.workdir / "sync_session_state.json", snapshot_data)
-    return snapshot_data
 
 
 class TestSnapshotCreation:

--- a/sync_tests/utils/db_sync/__init__.py
+++ b/sync_tests/utils/db_sync/__init__.py
@@ -43,6 +43,7 @@ def create_db_sync_config(
     pg_user: str | None = None,
     pg_dbname: str | None = None,
     pg_dir: pl.Path | None = None,
+    perf_stats_filename: str = "db_sync_performance_stats.json",
 ) -> DbSyncConfig:
     """Create a DbSyncConfig instance from environment variables and parameters."""
     return db_sync_config.create_db_sync_config(
@@ -53,6 +54,7 @@ def create_db_sync_config(
         pg_user=pg_user,
         pg_dbname=pg_dbname,
         pg_dir=pg_dir,
+        perf_stats_filename=perf_stats_filename,
     )
 
 

--- a/sync_tests/utils/db_sync/config.py
+++ b/sync_tests/utils/db_sync/config.py
@@ -80,6 +80,7 @@ def create_db_sync_config(
     pg_user: str | None = None,
     pg_dbname: str | None = None,
     pg_dir: pl.Path | None = None,
+    perf_stats_filename: str = "db_sync_performance_stats.json",
 ) -> DbSyncConfig:
     """Create a DbSyncConfig instance from environment variables and parameters.
 
@@ -91,6 +92,10 @@ def create_db_sync_config(
         pg_user: PostgreSQL user (defaults to current system user).
         pg_dbname: PostgreSQL database name (defaults to env name).
         pg_dir: PostgreSQL data directory (defaults to ``workdir / "postgres"``).
+        perf_stats_filename: Name of the perf-stats file under
+            ``workdir / "cardano-db-sync"``. Give each independent db-sync run in
+            the same session a distinct name so one run's stats file doesn't
+            overwrite another's.
 
     Returns:
         DbSyncConfig: A configuration instance with all paths and settings.
@@ -113,7 +118,7 @@ def create_db_sync_config(
         pg_dir = workdir / "postgres"
 
     # Build all paths relative to workdir.
-    perf_stats_file = workdir / "cardano-db-sync/db_sync_performance_stats.json"
+    perf_stats_file = workdir / "cardano-db-sync" / perf_stats_filename
     node_log_file = workdir / "node_sync.log"
     db_sync_log_file = workdir / "db_sync.log"
     epoch_sync_times_file = workdir / "cardano-db-sync/epoch_sync_times_dump.json"

--- a/sync_tests/utils/db_sync/snapshots.py
+++ b/sync_tests/utils/db_sync/snapshots.py
@@ -269,9 +269,12 @@ def create_db_sync_snapshot_stage_2(config: DbSyncConfig, stage_2_cmd: str) -> s
             (line for line in result.stdout.splitlines() if line.startswith("Created")),
             "Snapshot creation output not found.",
         )
-        snapshot_path = (
-            snapshot_line.split()[1] if "Created" in snapshot_line else "Snapshot path unknown"
-        )
+        if "Created" in snapshot_line:
+            # The script writes the snapshot relative to db_sync_dir (its cwd above),
+            # not the caller's cwd, so anchor it here to keep the path meaningful later.
+            snapshot_path = str(db_sync_dir / snapshot_line.split()[1])
+        else:
+            snapshot_path = "Snapshot path unknown"
     except subprocess.TimeoutExpired as e:
         msg = "Snapshot creation timed out."
         raise RuntimeError(msg) from e

--- a/sync_tests/utils/node/__init__.py
+++ b/sync_tests/utils/node/__init__.py
@@ -905,7 +905,9 @@ def wait_for_node_to_sync(env: str, base_dir: pl.Path) -> tuple:
         sync_duration_secs = int((end_dt - start_dt).total_seconds())
         era_dict["sync_duration_secs"] = sync_duration_secs
 
-        era_dict["sync_speed_sps"] = int(era_dict["slots_in_era"] / sync_duration_secs)
+        era_dict["sync_speed_sps"] = (
+            int(era_dict["slots_in_era"] / sync_duration_secs) if sync_duration_secs > 0 else 0
+        )
 
     # Calculate and add "end_sync_time" and "sync_duration_secs" for each epoch
     epoch_list = list(epoch_details_dict.keys())


### PR DESCRIPTION
## Summary

Arthur asked about deleting the snapshot creation/restoration tests (#164), since he'd never run them through this codebase and assumed they didn't work anymore. Turned out the testnet path (create a snapshot, restore it, restart db-sync, confirm it resyncs) already existed and matches what he actually needs, but it hadn't been exercised in CI in months. Ran it for real and it failed. This fixes what was actually broken.

Five bugs, each only visible after fixing the one before it:

- Test files collect alphabetically, so the restoration test ran before the creation test and wiped the database creation needed to read from. Restoration now takes the creation result as a direct fixture dependency, so pytest always runs creation first.
- `postgres-start.sh` only killed the first PID `lsof` returned, so a port with more than one listener (normal after a real sync) left postgres alive and the following cleanup crashed. Now kills each PID and waits for the port to clear.
- Importing that fixture across two test files made pytest run it twice instead of sharing it. Moved it into `conftest.py`, the only place that guarantees one shared instance.
- The snapshot file path was being resolved against the wrong working directory, so restoration looked for it one folder too high. Fixed at the source instead of patching the resolve call, since that function has a second, unrelated caller with different path semantics.
- An era that finishes syncing in under a second (exactly what should happen right after a restore) divided by zero. Now reports 0 speed instead of crashing.

Confirmed passing end to end on `preview`: https://github.com/IntersectMBO/cardano-sync-tests/actions/runs/31015477492 (all 5 snapshot creation/restoration tests pass)

One unrelated, pre-existing test (`test_sync_dbsync.py::test_perf_stats_written`) failed in that same run. Different test failed differently in the run before that too. Looks like flakiness from dispatching several runs back to back on the same self-hosted runner, not something these changes touch. Not fixed here.

`test_iohk_snapshot_restoration.py` (official mainnet-only snapshot restore) is untouched, separate question.

## Test plan

- [x] ruff, mypy, pre-commit clean on every touched file
- [x] Verified the fixture-ordering fix against a throwaway pytest reproduction before touching the real code, since the first attempt at it was subtly wrong
- [x] Verified the postgres kill fix against 3 real processes bound to one port locally
- [x] Full CI dispatch on preview, `run_only_sync_test=false`, twice more after intermediate failures, until clean: https://github.com/IntersectMBO/cardano-sync-tests/actions/runs/31015477492